### PR TITLE
chore: relax dependency lower bounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ readme = "README.md"
 actix-tls = { version = "3.4", features = ["rustls-0_23"] }
 actix-web = { version = "4.6", default-features = false, features = ["rustls-0_23"] }
 async-convert = "1"
-axum = { version = "0.8.9", default-features = false }
+axum = { version = "0.8", default-features = false }
 axum-extra = { version = "0.12", default-features = false }
 axum-server = { version = "0.8" }
-clap = "4.6.1"
+clap = "4.5.48"
 clap-cargo = "0.18"
 clap-verbosity-flag = { version = "3.0.1", default-features = false }
 color-eyre = "0.6"
@@ -31,13 +31,13 @@ http-body-util = "0.1.2"
 nutype = { version = "0.6", features = ["serde"] }
 percent-encoding = "2.3"
 rcgen = "0.14"
-reqwest = { version = "0.13.2", default-features = false, features = ["rustls-no-provider"] }
-rustls = "0.23.38"
+reqwest = { version = "0.13", default-features = false, features = ["rustls-no-provider"] }
+rustls = "0.23.27"
 serde = { version = "1.0.221", features = ["derive"] }
 serde_json = "1.0.45"
 serde_with = "3"
 thiserror = "2"
-tokio = "1.52"
+tokio = "1.41"
 tower = "0.5.2"
 tower-http = { version = "0.6.8" }
 tracing = "0.1.37"

--- a/webfinger-rs/Cargo.toml
+++ b/webfinger-rs/Cargo.toml
@@ -21,9 +21,9 @@ axum = ["dep:axum", "dep:axum-extra"]
 reqwest = ["dep:reqwest"]
 
 [dependencies]
-actix-web = { version = "4", optional = true }
+actix-web = { version = "4.6", optional = true }
 async-convert = "1"
-axum = { version = "0.8.9", optional = true, default-features = false, features = ["json"] }
+axum = { version = "0.8", optional = true, default-features = false, features = ["json"] }
 axum-extra = { version = "0.12", optional = true, default-features = false, features = ["query"] }
 http = "1.1"
 nutype = { version = "0.6", features = ["serde"] }

--- a/webfinger-rs/examples/actix.rs
+++ b/webfinger-rs/examples/actix.rs
@@ -5,7 +5,7 @@ use color_eyre::Result;
 use color_eyre::eyre::{Context, eyre};
 use rustls::ServerConfig;
 use tracing::info;
-use tracing::level_filters::LevelFilter;
+use tracing_subscriber::EnvFilter;
 use webfinger_rs::{Link, Rel, WELL_KNOWN_PATH, WebFingerRequest, WebFingerResponse};
 
 const SUBJECT: &str = "acct:carol@localhost";
@@ -13,9 +13,7 @@ const SUBJECT: &str = "acct:carol@localhost";
 #[actix_web::main]
 async fn main() -> Result<()> {
     color_eyre::install()?;
-    let env_filter = tracing_subscriber::EnvFilter::builder()
-        .with_default_directive(LevelFilter::INFO.into())
-        .from_env_lossy();
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
     tracing_subscriber::fmt().with_env_filter(env_filter).init();
 
     let addrs = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 3000);


### PR DESCRIPTION
## Summary

- relax workspace lower bounds for reqwest, rustls, axum, clap, and tokio to the lowest compatible versions proven by direct minimal-version checks
- align the optional Actix dependency floor with the workspace dev dependency
- keep the Actix example logging setup compatible with tracing-subscriber 0.3.0

## Verification

- cargo minimal-versions check --direct --workspace --all-features --all-targets
- cargo fmt --all --check
- cargo check --workspace --all-features --all-targets
- cargo test --workspace