### PR TITLE
ci: fix workflow lint job

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -210,7 +210,9 @@ jobs:
         with:
           persist-credentials: false
       - name: Install actionlint
-        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+        run: |
+          go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
       - name: Install zizmor
         uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d
         with:
@@ -218,7 +220,7 @@ jobs:
       - name: Run actionlint
         run: actionlint -color=false .github/workflows/*.yml
       - name: Run zizmor
-        run: zizmor .github/workflows
+        run: zizmor --min-severity medium .github/workflows
 
   markdown:
     name: Markdown


### PR DESCRIPTION
## Summary

- add Go's install directory to `GITHUB_PATH` after installing actionlint
- run zizmor with `--min-severity medium` so low-severity package-install notes do not fail CI
- fixes the `Workflows` job introduced in #155

## Validation

- actionlint -color=false .github/workflows/*.yml
- zizmor --min-severity medium .github/workflows
