### PR TITLE
Use query parser in server extractors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,29 +465,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum-extra"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be44683b41ccb9ab2d23a5230015c9c3c55be97a25e4428366de8873103f7970"
-dependencies = [
- "axum-core",
- "bytes",
- "form_urlencoded",
- "futures-core",
- "futures-util",
- "http 1.4.2",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "serde_core",
- "serde_html_form",
- "serde_path_to_error",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "axum-server"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2370,19 +2347,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_html_form"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f2d7ff8a2140333718bb329f5c40fc5f0865b84c426183ce14c97d2ab8154f"
-dependencies = [
- "form_urlencoded",
- "indexmap 2.13.0",
- "itoa",
- "ryu",
- "serde_core",
-]
-
-[[package]]
 name = "serde_json"
 version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3120,7 +3084,6 @@ dependencies = [
  "actix-web",
  "async-convert",
  "axum",
- "axum-extra",
  "axum-server",
  "color-eyre",
  "http 1.4.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ actix-tls = { version = "3.4", features = ["rustls-0_23"] }
 actix-web = { version = "4.6", default-features = false, features = ["rustls-0_23"] }
 async-convert = "1"
 axum = { version = "0.8", default-features = false }
-axum-extra = { version = "0.12", default-features = false }
 axum-server = { version = "0.8" }
 clap = "4.5.48"
 clap-cargo = "0.18"

--- a/webfinger-rs/Cargo.toml
+++ b/webfinger-rs/Cargo.toml
@@ -16,7 +16,7 @@ default = []
 ## Provides integration with the Actix web framework.
 actix = ["dep:actix-web", "dep:time"]
 ## Provides integration with the Axum web framework.
-axum = ["dep:axum", "dep:axum-extra"]
+axum = ["dep:axum"]
 ## Provides integration with the Reqwest HTTP client.
 reqwest = ["dep:reqwest"]
 
@@ -24,7 +24,6 @@ reqwest = ["dep:reqwest"]
 actix-web = { version = "4.6", optional = true }
 async-convert = "1"
 axum = { version = "0.8", optional = true, default-features = false, features = ["json"] }
-axum-extra = { version = "0.12", optional = true, default-features = false, features = ["query"] }
 http = "1.1"
 nutype = { version = "0.7", features = ["serde"] }
 percent-encoding = "2.3"

--- a/webfinger-rs/src/actix.rs
+++ b/webfinger-rs/src/actix.rs
@@ -26,10 +26,8 @@
 //! # assert_eq!(WELL_KNOWN_PATH, "/.well-known/webfinger");
 //! ```
 //!
-//! If extraction fails, Actix currently returns `400 Bad Request` for missing `resource` or
-//! missing host values. Malformed `resource` values are not currently mapped into an Actix error;
-//! they panic during extraction because request construction uses
-//! [`WebFingerRequest::builder`][crate::WebFingerRequest::builder] with `unwrap()`.
+//! If extraction fails, Actix returns `400 Bad Request` for missing or duplicated `resource`,
+//! missing host values, invalid percent encoding, or invalid resource URIs.
 //!
 //! See also [`WebFingerRequest`] for the extractor impl, [`WebFingerResponse`] for the responder
 //! impl, and the [Actix example] for a runnable server.
@@ -38,15 +36,16 @@
 //! [Actix example]:
 //!     https://github.com/joshka/webfinger-rs/blob/main/webfinger-rs/examples/actix.rs
 
-use std::future::Future;
-use std::pin::Pin;
+use std::future::{Ready, ready};
 
 use actix_web::dev::Payload;
+use actix_web::error::ErrorBadRequest;
 use actix_web::web::Json;
-use actix_web::{FromRequest, HttpRequest, HttpResponse, Responder};
+use actix_web::{Error as ActixError, FromRequest, HttpRequest, HttpResponse, Responder};
 use tracing::trace;
 
-use crate::{WebFingerRequest, WebFingerResponse};
+use crate::query::{RequestParams, RequestParamsError};
+use crate::{Rel, WebFingerRequest, WebFingerResponse};
 
 impl Responder for WebFingerResponse {
     /// Converts a [`WebFingerResponse`] into an Actix response.
@@ -98,20 +97,20 @@ impl FromRequest for WebFingerRequest {
     /// The extractor reads:
     ///
     /// - the host from the request URI authority or the HTTP `Host` header;
-    /// - the `resource` query parameter from the raw query string; and
-    /// - every repeated `rel` query parameter from that same raw query string.
+    /// - the decoded `resource` query parameter; and
+    /// - every repeated decoded `rel` query parameter.
     ///
-    /// The query parsing is intentionally simple and follows the current implementation rather than
-    /// Actix's typed query extractor.
+    /// Query parsing percent-decodes parameters while preserving RFC 3986 query semantics.
     ///
     /// # Errors
     ///
-    /// - If the request has no `resource` query parameter, extraction returns
-    ///   `ErrorBadRequest("missing resource")`.
+    /// - If the request has zero or more than one `resource` query parameter, extraction returns a
+    ///   bad request.
     /// - If the request has no URI authority and no `Host` header, extraction returns
     ///   `ErrorBadRequest("missing host")`.
-    /// - If `resource` is present but cannot be parsed by [`WebFingerRequest::builder`], the
-    ///   current implementation panics instead of returning an Actix error.
+    /// - If the query contains malformed percent encoding, extraction returns a bad request.
+    /// - If `resource` is present but cannot be parsed as a URI, extraction returns
+    ///   `ErrorBadRequest("invalid resource: ...")`.
     ///
     /// See also the [`crate::actix`] module docs and the [Actix example].
     ///
@@ -132,36 +131,374 @@ impl FromRequest for WebFingerRequest {
     ///
     /// [Actix example]:
     ///     https://github.com/joshka/webfinger-rs/blob/main/webfinger-rs/examples/actix.rs
-    type Error = actix_web::Error;
+    type Error = ActixError;
 
-    type Future = Pin<Box<dyn Future<Output = Result<Self, Self::Error>> + Send>>;
+    type Future = Ready<Result<Self, Self::Error>>;
 
     fn from_request(req: &HttpRequest, _: &mut Payload) -> Self::Future {
         trace!(?req, "extracting WebFingerRequest from request");
-        let host = req
-            .uri()
-            .host()
-            .or_else(|| req.headers().get("host").and_then(|h| h.to_str().ok()))
-            .map(|h| h.to_string());
-        let resource = req
-            .query_string()
-            .split('&')
-            .find_map(|param| param.split_once('=').filter(|(key, _)| *key == "resource"))
-            .map(|(_, value)| value.to_string());
-        let rels_from_query: Vec<_> = req
-            .query_string()
-            .split('&')
-            .filter_map(|param| param.split_once('=').filter(|(key, _)| *key == "rel"))
-            .map(|(_, value)| value.to_string())
-            .collect();
-        Box::pin(async move {
-            let resource = resource.ok_or(actix_web::error::ErrorBadRequest("missing resource"))?;
-            let host = host.ok_or(actix_web::error::ErrorBadRequest("missing host"))?;
-            let mut request_builder = WebFingerRequest::builder(resource).unwrap().host(host);
-            for rel in rels_from_query {
-                request_builder = request_builder.rel(rel);
-            }
-            Ok(request_builder.build())
-        })
+        ready(extract_request(req))
+    }
+}
+
+/// Extracts WebFinger request data from Actix request metadata.
+///
+/// WebFinger request extraction only needs URI, host, and query metadata from RFC 7033 sections 4.1
+/// and 4.2, so the fallible work can stay synchronous and the Actix [`FromRequest`] implementation
+/// can wrap the result in a ready future.
+fn extract_request(req: &HttpRequest) -> Result<WebFingerRequest, ActixError> {
+    let host = req
+        .uri()
+        .host()
+        .or_else(|| req.headers().get("host").and_then(|h| h.to_str().ok()))
+        .map(|h| h.to_string())
+        .ok_or(ErrorBadRequest("missing host"))?;
+    let query = req.query_string().parse::<RequestParams>()?;
+    let resource = query
+        .resource
+        .parse()
+        .map_err(|error| ErrorBadRequest(format!("invalid resource: {error}")))?;
+    let rels = query.rel.into_iter().map(Rel::from).collect();
+    Ok(WebFingerRequest {
+        host,
+        resource,
+        rels,
+    })
+}
+
+impl From<RequestParamsError> for ActixError {
+    fn from(error: RequestParamsError) -> Self {
+        ErrorBadRequest(error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use actix_web::body::to_bytes;
+    use actix_web::http::StatusCode;
+    use actix_web::{App, HttpResponse, test, web};
+
+    use super::*;
+    use crate::WELL_KNOWN_PATH;
+
+    type Result<T = (), E = Box<dyn std::error::Error>> = std::result::Result<T, E>;
+
+    /// Returns the extracted resource so tests can assert RFC 7033 query decoding behavior.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.1>.
+    async fn webfinger(request: WebFingerRequest) -> HttpResponse {
+        HttpResponse::Ok().body(request.resource.to_string())
+    }
+
+    /// Returns extracted relation filters so tests can assert RFC 7033 repeated `rel` handling.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.3>.
+    async fn webfinger_rels(request: WebFingerRequest) -> HttpResponse {
+        let rels = request
+            .rels
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        HttpResponse::Ok().json(rels)
+    }
+
+    /// Accepts a percent-encoded `acct:` resource without panicking.
+    ///
+    /// The resource query value is percent-encoded under RFC 7033 section 4.1, then parsed as a
+    /// URI query target under RFC 7033 section 4.2.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.1> and
+    /// <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.2>.
+    #[actix_web::test]
+    async fn valid_percent_encoded_resource() -> Result {
+        let app = App::new().route(WELL_KNOWN_PATH, web::get().to(webfinger));
+        let app = test::init_service(app).await;
+        let uri = format!("{WELL_KNOWN_PATH}?resource=acct%3Abad%40example.org");
+        let request = test::TestRequest::get()
+            .uri(&uri)
+            .insert_header(("host", "example.org"))
+            .to_request();
+
+        let response = test::call_service(&app, request).await;
+
+        assert_eq!(response.status(), StatusCode::OK, "{response:?}");
+        let body = to_bytes(response.into_body()).await?;
+        assert_eq!(body.as_ref(), b"acct:bad@example.org");
+        Ok(())
+    }
+
+    /// Converts malformed resource values into Actix bad-request responses.
+    ///
+    /// RFC 7033 section 4.2 requires absent or malformed `resource` parameters to be treated as bad
+    /// requests instead of panicking inside extraction.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.2>.
+    #[actix_web::test]
+    async fn request_with_invalid_resource() -> Result {
+        let app = App::new().route(WELL_KNOWN_PATH, web::get().to(webfinger));
+        let app = test::init_service(app).await;
+        let uri = format!("{WELL_KNOWN_PATH}?resource=http%3A%2F%2F%5B%3A%3A1");
+        let request = test::TestRequest::get()
+            .uri(&uri)
+            .insert_header(("host", "example.org"))
+            .to_request();
+
+        let response = test::call_service(&app, request).await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{response:?}");
+        let body = to_bytes(response.into_body()).await?;
+        assert_eq!(body.as_ref(), b"invalid resource: invalid authority");
+        Ok(())
+    }
+
+    /// Preserves repeated `rel` parameters instead of collapsing them.
+    ///
+    /// WebFinger clients use repeated `rel` keys to request multiple relation filters. A generic
+    /// map-shaped query parser can easily keep only one value, which would make handlers see an
+    /// incomplete request.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.1>.
+    #[actix_web::test]
+    async fn valid_request_with_repeated_rel_params() -> Result {
+        let app = App::new().route(WELL_KNOWN_PATH, web::get().to(webfinger_rels));
+        let app = test::init_service(app).await;
+        let resource = "acct%3Acarol%40example.org";
+        let uri = format!("{WELL_KNOWN_PATH}?resource={resource}&rel=profile&rel=avatar");
+        let request = test::TestRequest::get()
+            .uri(&uri)
+            .insert_header(("host", "example.org"))
+            .to_request();
+
+        let response = test::call_service(&app, request).await;
+
+        assert_eq!(response.status(), StatusCode::OK, "{response:?}");
+        let body = to_bytes(response.into_body()).await?;
+        assert_eq!(body.as_ref(), br#"["profile","avatar"]"#);
+        Ok(())
+    }
+
+    /// Exposes decoded relation URIs to Actix handlers.
+    ///
+    /// The shared parser owns the RFC 3986 percent-decoding rule; this adapter test proves Actix
+    /// handlers receive decoded `Rel` values rather than raw query text.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.1> and
+    /// <https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1>.
+    #[actix_web::test]
+    async fn rel_params_are_percent_decoded() -> Result {
+        let app = App::new().route(WELL_KNOWN_PATH, web::get().to(webfinger_rels));
+        let app = test::init_service(app).await;
+        let resource = "acct%3Acarol%40example.org";
+        let rel = "http%3A%2F%2Fwebfinger.example%2Frel%2Fprofile-page";
+        let uri = format!("{WELL_KNOWN_PATH}?resource={resource}&rel={rel}");
+        let request = test::TestRequest::get()
+            .uri(&uri)
+            .insert_header(("host", "example.org"))
+            .to_request();
+
+        let response = test::call_service(&app, request).await;
+
+        assert_eq!(response.status(), StatusCode::OK, "{response:?}");
+        let body = to_bytes(response.into_body()).await?;
+        assert_eq!(
+            body.as_ref(),
+            br#"["http://webfinger.example/rel/profile-page"]"#,
+        );
+        Ok(())
+    }
+
+    /// Converts invalid UTF-8 after percent decoding into an Actix bad-request response.
+    ///
+    /// The shared parser owns the byte-level validation; this adapter test proves malformed
+    /// percent-encoded bytes do not reach an Actix handler as relation strings.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1>.
+    #[actix_web::test]
+    async fn invalid_percent_encoded_rel_is_bad_request() -> Result {
+        let app = App::new().route(WELL_KNOWN_PATH, web::get().to(webfinger_rels));
+        let app = test::init_service(app).await;
+        let resource = "acct%3Acarol%40example.org";
+        let uri = format!("{WELL_KNOWN_PATH}?resource={resource}&rel=%FF");
+        let request = test::TestRequest::get()
+            .uri(&uri)
+            .insert_header(("host", "example.org"))
+            .to_request();
+
+        let response = test::call_service(&app, request).await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{response:?}");
+        let body = to_bytes(response.into_body()).await?;
+        assert_eq!(body.as_ref(), b"invalid percent-encoded query parameter");
+        Ok(())
+    }
+
+    /// Rejects malformed percent escape syntax instead of treating `%` literally.
+    ///
+    /// The shared query parser owns the RFC 3986 check; this Actix test proves that parser errors are
+    /// converted into `400 Bad Request` responses instead of escaping the extractor boundary.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1>.
+    #[actix_web::test]
+    async fn malformed_percent_escape_is_bad_request() -> Result {
+        let app = App::new().route(WELL_KNOWN_PATH, web::get().to(webfinger_rels));
+        let app = test::init_service(app).await;
+        let resource = "acct%3Acarol%40example.org";
+        let uri = format!("{WELL_KNOWN_PATH}?resource={resource}&rel=%GG");
+        let request = test::TestRequest::get()
+            .uri(&uri)
+            .insert_header(("host", "example.org"))
+            .to_request();
+
+        let response = test::call_service(&app, request).await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{response:?}");
+        let body = to_bytes(response.into_body()).await?;
+        assert_eq!(body.as_ref(), b"invalid percent-encoded query parameter");
+        Ok(())
+    }
+
+    /// Accepts `resource` in any query parameter position through the Actix extractor.
+    ///
+    /// RFC 7033 section 4.1 does not make parameter order significant. This adapter test proves
+    /// Actix handlers still receive relation filters when `resource` appears after them.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.1>.
+    #[actix_web::test]
+    async fn resource_parameter_order_does_not_matter() -> Result {
+        let app = App::new().route(WELL_KNOWN_PATH, web::get().to(webfinger_rels));
+        let app = test::init_service(app).await;
+        let resource = "acct%3Acarol%40example.org";
+        let uri = format!("{WELL_KNOWN_PATH}?rel=profile&resource={resource}");
+        let request = test::TestRequest::get()
+            .uri(&uri)
+            .insert_header(("host", "example.org"))
+            .to_request();
+
+        let response = test::call_service(&app, request).await;
+
+        assert_eq!(response.status(), StatusCode::OK, "{response:?}");
+        let body = to_bytes(response.into_body()).await?;
+        assert_eq!(body.as_ref(), br#"["profile"]"#);
+        Ok(())
+    }
+
+    /// Keeps encoded `=` and `&` inside handler-visible resource values.
+    ///
+    /// Resource URIs may contain query strings of their own. This adapter test proves Actix receives
+    /// the decoded target resource without splitting encoded inner delimiters into WebFinger
+    /// parameters.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.1>.
+    #[actix_web::test]
+    async fn encoded_delimiters_stay_inside_resource() -> Result {
+        let app = App::new().route(WELL_KNOWN_PATH, web::get().to(webfinger));
+        let app = test::init_service(app).await;
+        let resource = "https%3A%2F%2Fexample.org%2Fprofile%3Fa%3D1%26b%3D2";
+        let uri = format!("{WELL_KNOWN_PATH}?resource={resource}");
+        let request = test::TestRequest::get()
+            .uri(&uri)
+            .insert_header(("host", "example.org"))
+            .to_request();
+
+        let response = test::call_service(&app, request).await;
+
+        assert_eq!(response.status(), StatusCode::OK, "{response:?}");
+        let body = to_bytes(response.into_body()).await?;
+        assert_eq!(body.as_ref(), b"https://example.org/profile?a=1&b=2");
+        Ok(())
+    }
+
+    /// Preserves literal `+` in Actix handler-visible resources.
+    ///
+    /// Actix's normal query extractor is not used here because WebFinger follows RFC 3986 query
+    /// semantics, where `+` remains data instead of becoming a space.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc3986.html#section-3.4>.
+    #[actix_web::test]
+    async fn plus_is_not_decoded_as_space() -> Result {
+        let app = App::new().route(WELL_KNOWN_PATH, web::get().to(webfinger));
+        let app = test::init_service(app).await;
+        let uri = format!("{WELL_KNOWN_PATH}?resource=acct%3Acarol+tag%40example.org");
+        let request = test::TestRequest::get()
+            .uri(&uri)
+            .insert_header(("host", "example.org"))
+            .to_request();
+
+        let response = test::call_service(&app, request).await;
+
+        assert_eq!(response.status(), StatusCode::OK, "{response:?}");
+        let body = to_bytes(response.into_body()).await?;
+        assert_eq!(body.as_ref(), b"acct:carol+tag@example.org");
+        Ok(())
+    }
+
+    /// Rejects duplicate `resource` parameters at the Actix extractor boundary.
+    ///
+    /// The parser owns the RFC 7033 section 4.2 rule that there is exactly one target. This adapter
+    /// test proves ambiguous requests become `400 Bad Request` responses rather than arbitrary
+    /// handler inputs.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.2>.
+    #[actix_web::test]
+    async fn request_with_multiple_resources() -> Result {
+        let app = App::new().route(WELL_KNOWN_PATH, web::get().to(webfinger));
+        let app = test::init_service(app).await;
+        let carol = "acct%3Acarol%40example.org";
+        let alice = "acct%3Aalice%40example.org";
+        let uri = format!("{WELL_KNOWN_PATH}?resource={carol}&resource={alice}");
+        let request = test::TestRequest::get()
+            .uri(&uri)
+            .insert_header(("host", "example.org"))
+            .to_request();
+
+        let response = test::call_service(&app, request).await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{response:?}");
+        let body = to_bytes(response.into_body()).await?;
+        assert_eq!(body.as_ref(), b"multiple resource parameters");
+        Ok(())
+    }
+
+    /// Rejects requests that omit the required `resource` parameter.
+    ///
+    /// The shared query parser owns the exact RFC 7033 rule; this Actix test proves that missing
+    /// `resource` is exposed as an Actix bad-request response.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.2>.
+    #[actix_web::test]
+    async fn request_with_missing_resource() -> Result {
+        let app = App::new().route(WELL_KNOWN_PATH, web::get().to(webfinger));
+        let app = test::init_service(app).await;
+        let request = test::TestRequest::get()
+            .uri(WELL_KNOWN_PATH)
+            .insert_header(("host", "example.org"))
+            .to_request();
+
+        let response = test::call_service(&app, request).await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{response:?}");
+        let body = to_bytes(response.into_body()).await?;
+        assert_eq!(body.as_ref(), b"missing resource parameter");
+        Ok(())
+    }
+
+    /// Rejects requests where neither the URI nor `Host` header provides an authority.
+    ///
+    /// The request host is significant to WebFinger query routing.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4>.
+    #[actix_web::test]
+    async fn request_with_no_host() -> Result {
+        let app = App::new().route(WELL_KNOWN_PATH, web::get().to(webfinger));
+        let app = test::init_service(app).await;
+        let uri = format!("{WELL_KNOWN_PATH}?resource=acct%3Abad%40example.org");
+        let request = test::TestRequest::get().uri(&uri).to_request();
+
+        let response = test::call_service(&app, request).await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{response:?}");
+        let body = to_bytes(response.into_body()).await?;
+        assert_eq!(body.as_ref(), b"missing host");
+        Ok(())
     }
 }

--- a/webfinger-rs/src/axum.rs
+++ b/webfinger-rs/src/axum.rs
@@ -25,7 +25,8 @@
 //! ```
 //!
 //! If extraction fails, Axum receives [`Rejection`], which returns `400 Bad Request` with a plain
-//! text message for missing hosts, malformed query strings, or invalid resource URIs.
+//! text message for missing or duplicated `resource`, missing host values, invalid percent
+//! encoding, or invalid resource URIs.
 //!
 //! See also [`WebFingerRequest`] for the extractor impl, [`WebFingerResponse`] for the responder
 //! impl, and the [Axum example] for a runnable server.
@@ -37,13 +38,13 @@
 use axum::Json;
 use axum::extract::FromRequestParts;
 use axum::response::{IntoResponse, Response as AxumResponse};
-use axum_extra::extract::{Query, QueryRejection};
 use http::header::{self, HOST};
 use http::request::Parts;
 use http::uri::InvalidUri;
 use http::{HeaderValue, StatusCode};
 use tracing::trace;
 
+use crate::query::{RequestParams, RequestParamsError};
 use crate::{Rel, WebFingerRequest, WebFingerResponse};
 
 const JRD_CONTENT_TYPE: HeaderValue = HeaderValue::from_static("application/jrd+json");
@@ -96,15 +97,6 @@ impl IntoResponse for WebFingerResponse {
     }
 }
 
-/// The query parameters for a WebFinger request.
-#[derive(Debug, serde::Deserialize)]
-struct RequestParams {
-    resource: String,
-
-    #[serde(default)]
-    rel: Vec<String>,
-}
-
 /// Rejection type for WebFinger requests.
 ///
 /// This represents errors that can occur while extracting [`WebFingerRequest`] from Axum request
@@ -114,12 +106,12 @@ struct RequestParams {
 ///
 /// - [`Rejection::MissingHost`] when neither the request URI nor the `Host` header provides an
 ///   authority;
-/// - [`Rejection::InvalidQueryString`] when the query string is missing `resource` or otherwise
-///   fails deserialization by [`axum_extra::extract::Query`]; and
+/// - [`Rejection::InvalidQueryString`] when the query string is missing `resource`, contains more
+///   than one `resource`, or contains malformed percent encoding; and
 /// - [`Rejection::InvalidResource`] when `resource` is present but cannot be parsed as an
 ///   [`http::Uri`].
 pub enum Rejection {
-    /// The `resource` query parameter is missing or invalid.
+    /// The WebFinger query string is missing required data or is malformed.
     InvalidQueryString(String),
 
     /// The `Host` header is missing.
@@ -139,16 +131,16 @@ impl IntoResponse for Rejection {
     fn into_response(self) -> AxumResponse {
         let message = match self {
             Rejection::MissingHost => "missing host".to_string(),
-            Rejection::InvalidQueryString(e) => e.to_string(),
+            Rejection::InvalidQueryString(error) => error,
             Rejection::InvalidResource(e) => format!("invalid resource: {e}"),
         };
         (StatusCode::BAD_REQUEST, message).into_response()
     }
 }
 
-impl From<QueryRejection> for Rejection {
-    fn from(rejection: QueryRejection) -> Self {
-        Rejection::InvalidQueryString(rejection.to_string())
+impl From<RequestParamsError> for Rejection {
+    fn from(error: RequestParamsError) -> Self {
+        Rejection::InvalidQueryString(error.to_string())
     }
 }
 
@@ -174,8 +166,8 @@ impl<S: Send + Sync> FromRequestParts<S> for WebFingerRequest {
     ///
     /// - If the request has neither a URI authority nor a `Host` header, extraction fails with
     ///   `Rejection::MissingHost`.
-    /// - If the query string is missing `resource` or otherwise fails Axum query deserialization,
-    ///   extraction fails with `Rejection::InvalidQueryString`.
+    /// - If the query string is missing `resource`, contains more than one `resource`, or contains
+    ///   malformed percent encoding, extraction fails with `Rejection::InvalidQueryString`.
     /// - If `resource` is present but cannot be parsed as a URI, extraction fails with
     ///   `Rejection::InvalidResource`.
     ///
@@ -197,7 +189,7 @@ impl<S: Send + Sync> FromRequestParts<S> for WebFingerRequest {
     ///
     /// [Axum example]:
     ///     https://github.com/joshka/webfinger-rs/blob/main/webfinger-rs/examples/axum.rs
-    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         trace!("request parts: {:?}", parts);
 
         let host = parts
@@ -207,11 +199,9 @@ impl<S: Send + Sync> FromRequestParts<S> for WebFingerRequest {
             .map(str::to_string)
             .ok_or(Rejection::MissingHost)?;
 
-        // use axum::extract::Query instead of axum::extract::Query, so that we can accept multiple
-        // rel query parameters rather than this being provided as a sequence (`rel=[a,b,c]`).
-        let query = Query::<RequestParams>::from_request_parts(parts, state).await?;
+        let query = parts.uri.query().unwrap_or("").parse::<RequestParams>()?;
         let resource = query.resource.parse().map_err(Rejection::InvalidResource)?;
-        let rels = query.rel.clone().into_iter().map(Rel::from).collect();
+        let rels = query.rel.into_iter().map(Rel::from).collect();
 
         Ok(WebFingerRequest {
             host,
@@ -236,6 +226,7 @@ mod tests {
 
     /// A small helper trait to convert a response body into a string.
     trait IntoText {
+        /// Consumes the response body and decodes it as UTF-8 text.
         async fn into_text(self) -> Result<String>;
     }
 
@@ -247,16 +238,41 @@ mod tests {
         }
     }
 
+    /// Builds a test router using the resource-echoing WebFinger handler.
     fn app() -> axum::Router {
         axum::Router::new().route(WELL_KNOWN_PATH, get(webfinger))
     }
 
+    /// Builds a test router using the relation-echoing WebFinger handler.
+    fn rels_app() -> axum::Router {
+        axum::Router::new().route(WELL_KNOWN_PATH, get(webfinger_rels))
+    }
+
+    /// Returns a minimal JRD response so tests can assert resource extraction through Axum.
     async fn webfinger(request: WebFingerRequest) -> impl IntoResponse {
         WebFingerResponse::builder(request.resource.to_string()).build()
     }
 
+    /// Returns extracted relation filters so tests can assert RFC 7033 repeated `rel` handling.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.1>.
+    async fn webfinger_rels(request: WebFingerRequest) -> impl IntoResponse {
+        let rels = request
+            .rels
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        Json(rels)
+    }
+
     const VALID_RESOURCE: &str = "acct:carol@example.com";
 
+    /// Accepts an ordinary `acct:` resource from an absolute request URI.
+    ///
+    /// This covers the common Axum path where the request URI already contains the authority, so host
+    /// extraction should not depend on the `Host` header.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4>.
     #[tokio::test]
     async fn valid_request() -> Result {
         let uri = format!("https://example.com{WELL_KNOWN_PATH}?resource={VALID_RESOURCE}");
@@ -270,6 +286,12 @@ mod tests {
         Ok(())
     }
 
+    /// Accepts an ordinary `acct:` resource when only the `Host` header carries the authority.
+    ///
+    /// Axum tests usually build origin-form request URIs, so this catches regressions where the
+    /// extractor ignores the fallback authority that HTTP/1.1 clients send in `Host`.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4>.
     #[tokio::test]
     async fn valid_request_with_host_header() -> Result {
         let request = Request::builder()
@@ -285,6 +307,11 @@ mod tests {
         Ok(())
     }
 
+    /// Rejects requests where neither the URI nor `Host` header provides an authority.
+    ///
+    /// The request host is significant to WebFinger query routing.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4>.
     #[tokio::test]
     async fn request_with_no_host() -> Result {
         let uri = format!("{WELL_KNOWN_PATH}?resource={VALID_RESOURCE}");
@@ -298,6 +325,12 @@ mod tests {
         Ok(())
     }
 
+    /// Rejects requests that omit the required `resource` parameter.
+    ///
+    /// RFC 7033 section 4.2 treats absent `resource` parameters as bad requests. This prevents the
+    /// Axum adapter from relying on framework deserialization wording or accepting an empty target.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.2>.
     #[tokio::test]
     async fn request_with_missing_resource() -> Result {
         let request = Request::builder()
@@ -309,16 +342,19 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{response:?}");
         let body = response.into_text().await?;
-        assert_eq!(
-            body,
-            "Failed to deserialize query string: missing field `resource`",
-        );
+        assert_eq!(body, "missing resource parameter");
         Ok(())
     }
 
+    /// Converts malformed resource values into Axum bad-request responses.
+    ///
+    /// RFC 7033 section 4.2 requires malformed `resource` parameters to be treated as bad requests
+    /// instead of panicking inside extraction.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.2>.
     #[tokio::test]
     async fn request_with_invalid_resource() -> Result {
-        let uri = format!("https://example.com{WELL_KNOWN_PATH}?resource=%");
+        let uri = format!("https://example.com{WELL_KNOWN_PATH}?resource=http%3A%2F%2F%5B%3A%3A1");
         let request = Request::builder().uri(uri).body(Body::empty())?;
 
         let response = app().oneshot(request).await?;
@@ -326,6 +362,200 @@ mod tests {
         assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{response:?}");
         let body = response.into_text().await?;
         assert_eq!(body, "invalid resource: invalid authority");
+        Ok(())
+    }
+
+    /// Accepts a percent-encoded `acct:` resource without panicking.
+    ///
+    /// The resource query value is percent-encoded under RFC 7033 section 4.1, then parsed as a URI
+    /// query target under RFC 7033 section 4.2.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.1> and
+    /// <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.2>.
+    #[tokio::test]
+    async fn valid_percent_encoded_resource() -> Result {
+        let uri = format!("https://example.com{WELL_KNOWN_PATH}?resource=acct%3Abad%40example.org");
+        let request = Request::builder().uri(uri).body(Body::empty())?;
+
+        let response = app().oneshot(request).await?;
+
+        assert_eq!(response.status(), StatusCode::OK, "{response:?}");
+        let body = response.into_text().await?;
+        assert_eq!(body, r#"{"subject":"acct:bad@example.org","links":[]}"#);
+        Ok(())
+    }
+
+    /// Preserves repeated `rel` parameters instead of collapsing them.
+    ///
+    /// WebFinger clients use repeated `rel` keys to request multiple relation filters. A generic
+    /// map-shaped query parser can easily keep only one value, which would make handlers see an
+    /// incomplete request.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.1>.
+    #[tokio::test]
+    async fn valid_request_with_repeated_rel_params() -> Result {
+        let resource = "acct%3Acarol%40example.org";
+        let uri = format!(
+            "https://example.com{WELL_KNOWN_PATH}?resource={resource}&rel=profile&rel=avatar"
+        );
+        let request = Request::builder().uri(uri).body(Body::empty())?;
+
+        let response = rels_app().oneshot(request).await?;
+
+        assert_eq!(response.status(), StatusCode::OK, "{response:?}");
+        let body = response.into_text().await?;
+        assert_eq!(body, r#"["profile","avatar"]"#);
+        Ok(())
+    }
+
+    /// Exposes decoded relation URIs to Axum handlers.
+    ///
+    /// The shared parser owns the RFC 3986 percent-decoding rule; this adapter test proves Axum
+    /// handlers receive decoded `Rel` values rather than raw query text.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.1> and
+    /// <https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1>.
+    #[tokio::test]
+    async fn rel_params_are_percent_decoded() -> Result {
+        let resource = "acct%3Acarol%40example.org";
+        let rel = "http%3A%2F%2Fwebfinger.example%2Frel%2Fprofile-page";
+        let uri = format!("https://example.com{WELL_KNOWN_PATH}?resource={resource}&rel={rel}");
+        let request = Request::builder().uri(uri).body(Body::empty())?;
+
+        let response = rels_app().oneshot(request).await?;
+
+        assert_eq!(response.status(), StatusCode::OK, "{response:?}");
+        let body = response.into_text().await?;
+        assert_eq!(body, r#"["http://webfinger.example/rel/profile-page"]"#);
+        Ok(())
+    }
+
+    /// Converts invalid UTF-8 after percent decoding into an Axum bad-request response.
+    ///
+    /// The shared parser owns the byte-level validation; this adapter test proves malformed
+    /// percent-encoded bytes do not reach an Axum handler as relation strings.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1>.
+    #[tokio::test]
+    async fn invalid_percent_encoded_rel_is_bad_request() -> Result {
+        let resource = "acct%3Acarol%40example.org";
+        let uri = format!("https://example.com{WELL_KNOWN_PATH}?resource={resource}&rel=%FF");
+        let request = Request::builder().uri(uri).body(Body::empty())?;
+
+        let response = rels_app().oneshot(request).await?;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{response:?}");
+        let body = response.into_text().await?;
+        assert_eq!(body, "invalid percent-encoded query parameter");
+        Ok(())
+    }
+
+    /// Rejects malformed percent escape syntax instead of treating `%` literally.
+    ///
+    /// The shared query parser owns the RFC 3986 check; this Axum test proves that parser errors are
+    /// converted into `400 Bad Request` responses instead of escaping the extractor boundary.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1>.
+    #[tokio::test]
+    async fn malformed_percent_escape_is_bad_request() -> Result {
+        let resource = "acct%3Acarol%40example.org";
+        let uri = format!("https://example.com{WELL_KNOWN_PATH}?resource={resource}&rel=%GG");
+        let request = Request::builder().uri(uri).body(Body::empty())?;
+
+        let response = rels_app().oneshot(request).await?;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{response:?}");
+        let body = response.into_text().await?;
+        assert_eq!(body, "invalid percent-encoded query parameter");
+        Ok(())
+    }
+
+    /// Accepts `resource` in any query parameter position through the Axum extractor.
+    ///
+    /// RFC 7033 section 4.1 does not make parameter order significant. This adapter test proves
+    /// Axum handlers still receive relation filters when `resource` appears after them.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.1>.
+    #[tokio::test]
+    async fn resource_parameter_order_does_not_matter() -> Result {
+        let resource = "acct%3Acarol%40example.org";
+        let uri = format!("https://example.com{WELL_KNOWN_PATH}?rel=profile&resource={resource}");
+        let request = Request::builder().uri(uri).body(Body::empty())?;
+
+        let response = rels_app().oneshot(request).await?;
+
+        assert_eq!(response.status(), StatusCode::OK, "{response:?}");
+        let body = response.into_text().await?;
+        assert_eq!(body, r#"["profile"]"#);
+        Ok(())
+    }
+
+    /// Keeps encoded `=` and `&` inside handler-visible resource values.
+    ///
+    /// Resource URIs may contain query strings of their own. This adapter test proves Axum receives
+    /// the decoded target resource without splitting encoded inner delimiters into WebFinger
+    /// parameters.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.1>.
+    #[tokio::test]
+    async fn encoded_delimiters_stay_inside_resource() -> Result {
+        let resource = "https%3A%2F%2Fexample.org%2Fprofile%3Fa%3D1%26b%3D2";
+        let uri = format!("https://example.com{WELL_KNOWN_PATH}?resource={resource}");
+        let request = Request::builder().uri(uri).body(Body::empty())?;
+
+        let response = app().oneshot(request).await?;
+
+        assert_eq!(response.status(), StatusCode::OK, "{response:?}");
+        let body = response.into_text().await?;
+        assert_eq!(
+            body,
+            r#"{"subject":"https://example.org/profile?a=1&b=2","links":[]}"#,
+        );
+        Ok(())
+    }
+
+    /// Preserves literal `+` in Axum handler-visible resources.
+    ///
+    /// Framework form-query extractors are not used here because WebFinger follows RFC 3986 query
+    /// semantics, where `+` remains data instead of becoming a space.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc3986.html#section-3.4>.
+    #[tokio::test]
+    async fn plus_is_not_decoded_as_space() -> Result {
+        let uri =
+            format!("https://example.com{WELL_KNOWN_PATH}?resource=acct%3Acarol+tag%40example.org");
+        let request = Request::builder().uri(uri).body(Body::empty())?;
+
+        let response = app().oneshot(request).await?;
+
+        assert_eq!(response.status(), StatusCode::OK, "{response:?}");
+        let body = response.into_text().await?;
+        assert_eq!(
+            body,
+            r#"{"subject":"acct:carol+tag@example.org","links":[]}"#
+        );
+        Ok(())
+    }
+
+    /// Rejects duplicate `resource` parameters at the Axum extractor boundary.
+    ///
+    /// The parser owns the RFC 7033 section 4.2 rule that there is exactly one target. This adapter
+    /// test proves ambiguous requests become `400 Bad Request` responses rather than arbitrary
+    /// handler inputs.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.2>.
+    #[tokio::test]
+    async fn request_with_multiple_resources() -> Result {
+        let carol = "acct%3Acarol%40example.org";
+        let alice = "acct%3Aalice%40example.org";
+        let uri = format!("https://example.com{WELL_KNOWN_PATH}?resource={carol}&resource={alice}");
+        let request = Request::builder().uri(uri).body(Body::empty())?;
+
+        let response = app().oneshot(request).await?;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{response:?}");
+        let body = response.into_text().await?;
+        assert_eq!(body, "multiple resource parameters");
         Ok(())
     }
 }

--- a/webfinger-rs/src/lib.rs
+++ b/webfinger-rs/src/lib.rs
@@ -259,7 +259,7 @@ pub mod actix;
 pub mod axum;
 mod error;
 mod http;
-#[cfg(test)]
+#[cfg(any(feature = "actix", feature = "axum", test))]
 mod query;
 #[cfg(feature = "reqwest")]
 mod reqwest;


### PR DESCRIPTION
## Summary

Update the Actix and Axum extractors to use the shared WebFinger query parser.

This makes both server integrations handle incoming WebFinger requests consistently:

- percent-encoded `resource` values are decoded before URI parsing
- malformed resources become `400 Bad Request` instead of panicking
- missing or duplicate `resource` parameters become `400 Bad Request`
- repeated `rel` parameters are preserved
- malformed percent encoding is rejected
- literal `+` remains a plus instead of becoming a space

Fixes #158.

## Why This Is Necessary

The original Actix extractor parsed the raw query string manually and then unwrapped resource URI parsing. A malformed percent-encoded `resource` could therefore become an extractor panic instead of a normal bad request.

Axum had a related risk because it relied on `axum-extra::extract::Query`. That handles repeated values, but it is still form-style parsing. Keeping Actix and Axum on separate query paths also made it easy for the two integrations to drift.

The new shape keeps framework-specific code focused on HTTP extraction and error mapping, while the shared parser owns the WebFinger query contract.

## Dependency Change

The Axum extractor no longer uses `axum-extra::extract::Query`, so this removes the `axum-extra` dependency.

## Tests

- `cargo test -p webfinger-rs --features actix actix::tests`
- `cargo test -p webfinger-rs --features axum axum::tests`
- `cargo test -p webfinger-rs --all-features`
- `cargo test --workspace`
- `cargo clippy --workspace --all-features --all-targets`
