### PR TITLE
Preserve percent escapes in URLs

### DIFF
--- a/webfinger-rs/src/http.rs
+++ b/webfinger-rs/src/http.rs
@@ -9,7 +9,8 @@ use crate::{WELL_KNOWN_PATH, WebFingerRequest, WebFingerResponse};
 /// The set of values to percent encode
 ///
 /// Notably, this set does not include the `@`, `:`, `?`, and `/` characters which are allowed by
-/// RFC 3986 in the query component.
+/// RFC 3986 in the query component. It does include `%` so already-percent-encoded resource or
+/// relation URIs survive WebFinger query parsing as literal percent escapes in the target value.
 ///
 /// See the following RFCs for more information:
 /// - <https://www.rfc-editor.org/rfc/rfc7033#section-4.1>
@@ -24,6 +25,7 @@ const QUERY: AsciiSet = percent_encoding::CONTROLS
     .add(b' ')
     .add(b'"')
     .add(b'#')
+    .add(b'%')
     .add(b'<')
     .add(b'>')
     .add(b'[')
@@ -81,5 +83,58 @@ impl TryFrom<&WebFingerResponse> for http::Response<()> {
         http::Response::builder()
             .header("Content-Type", "application/jrd+json")
             .body(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Rel;
+
+    /// Percent-encodes literal percent signs in the outgoing `resource` value.
+    ///
+    /// RFC 7033 section 4.1 puts the resource URI inside a WebFinger query parameter. If the target
+    /// URI already contains percent escapes, the `%` signs must become `%25` in the outer query or a
+    /// server will decode them as part of the WebFinger parameter and change the target resource.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.1> and
+    /// <https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1>.
+    #[test]
+    fn outgoing_resource_preserves_inner_percent_escapes() {
+        let request = WebFingerRequest {
+            resource: "https://example.org/profile/a%20b".parse().unwrap(),
+            host: "example.org".to_string(),
+            rels: Vec::new(),
+        };
+
+        let uri = Uri::try_from(&request).unwrap();
+
+        assert_eq!(
+            uri.to_string(),
+            "https://example.org/.well-known/webfinger?resource=https://example.org/profile/a%2520b",
+        );
+    }
+
+    /// Percent-encodes literal percent signs in outgoing `rel` values.
+    ///
+    /// Relation filters are also WebFinger query parameter values. Encoding `%` prevents an already
+    /// escaped relation URI from being decoded one level too far by the receiving WebFinger server.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.1> and
+    /// <https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1>.
+    #[test]
+    fn outgoing_rel_preserves_inner_percent_escapes() {
+        let request = WebFingerRequest {
+            resource: "acct:carol@example.org".parse().unwrap(),
+            host: "example.org".to_string(),
+            rels: vec![Rel::from("https://example.org/rel/a%2Fb")],
+        };
+
+        let uri = Uri::try_from(&request).unwrap();
+
+        assert_eq!(
+            uri.to_string(),
+            "https://example.org/.well-known/webfinger?resource=acct:carol@example.org&rel=https://example.org/rel/a%252Fb",
+        );
     }
 }


### PR DESCRIPTION
## Summary

Percent-encode literal `%` signs when constructing outgoing WebFinger request URLs.

This preserves resource and relation URI values that already contain percent escapes. For example, an inner target URI containing `%20` should arrive at the WebFinger server as `%20`, not as a decoded space.

## Why This Is Necessary

WebFinger puts a resource URI or relation URI inside an outer WebFinger query parameter. If the inner value already contains a percent escape, such as `%20`, the outer query must encode the literal percent sign as `%25`.

Otherwise, a server that correctly decodes the WebFinger query parameter once will accidentally decode part of the inner URI value too. That changes the requested resource or relation.

## Tests

- `cargo test -p webfinger-rs http::tests`
- `cargo test -p webfinger-rs query::tests`
- `cargo test --workspace`
- `cargo clippy --workspace --all-features --all-targets`
