### PR TITLE
fix: add WebFinger CORS header

### DIFF
--- a/webfinger-rs/src/actix.rs
+++ b/webfinger-rs/src/actix.rs
@@ -3,7 +3,7 @@
 //! Enable the `actix` feature to:
 //!
 //! - extract [`WebFingerRequest`] from requests routed to [`crate::WELL_KNOWN_PATH`]; and
-//! - return [`WebFingerResponse`] directly from Actix handlers.
+//! - return [`WebFingerResponse`] directly from Actix handlers with the WebFinger CORS header.
 //!
 //! The extractor reads the standard WebFinger query shape from [RFC 7033 section 4.1]:
 //!
@@ -40,22 +40,24 @@ use std::future::{Ready, ready};
 
 use actix_web::dev::Payload;
 use actix_web::error::ErrorBadRequest;
+use actix_web::http::header::{ACCESS_CONTROL_ALLOW_ORIGIN, HeaderValue};
 use actix_web::web::Json;
 use actix_web::{Error as ActixError, FromRequest, HttpRequest, HttpResponse, Responder};
 use tracing::trace;
 
+use crate::http::CORS_ALLOW_ORIGIN;
 use crate::query::{RequestParams, RequestParamsError};
 use crate::{Rel, WebFingerRequest, WebFingerResponse};
+
+const CORS_ALLOW_ORIGIN_HEADER: HeaderValue = HeaderValue::from_static(CORS_ALLOW_ORIGIN);
 
 impl Responder for WebFingerResponse {
     /// Converts a [`WebFingerResponse`] into an Actix response.
     ///
     /// This delegates to [`actix_web::web::Json`], so the body is serialized as JSON and the
     /// response `Content-Type` follows Actix's JSON responder behavior, which is currently
-    /// `application/json`.
-    ///
-    /// Unlike the Axum integration, this responder does not currently override the content type to
-    /// `application/jrd+json`.
+    /// `application/json`. It also sets `Access-Control-Allow-Origin: *` as recommended by RFC
+    /// 7033 section 5.
     ///
     /// See also the [`crate::actix`] module docs and the [Actix example].
     ///
@@ -86,8 +88,12 @@ impl Responder for WebFingerResponse {
     ///     https://github.com/joshka/webfinger-rs/blob/main/webfinger-rs/examples/actix.rs
     type Body = <Json<WebFingerResponse> as Responder>::Body;
 
-    fn respond_to(self, _request: &HttpRequest) -> HttpResponse<Self::Body> {
-        Json(self).respond_to(_request)
+    fn respond_to(self, request: &HttpRequest) -> HttpResponse<Self::Body> {
+        let mut response = Json(self).respond_to(request);
+        response
+            .headers_mut()
+            .insert(ACCESS_CONTROL_ALLOW_ORIGIN, CORS_ALLOW_ORIGIN_HEADER);
+        response
     }
 }
 
@@ -200,6 +206,33 @@ mod tests {
             .map(ToString::to_string)
             .collect::<Vec<_>>();
         HttpResponse::Ok().json(rels)
+    }
+
+    /// Returns a minimal JRD so tests can assert responder-owned WebFinger headers.
+    async fn webfinger_response() -> WebFingerResponse {
+        WebFingerResponse::new("acct:carol@example.com")
+    }
+
+    /// Includes the RFC 7033 CORS header on successful JRD responses.
+    ///
+    /// WebFinger resources must be queryable from browsers, and RFC 7033 section 5 recommends the
+    /// least restrictive `Access-Control-Allow-Origin` value for public WebFinger resources.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-5>.
+    #[actix_web::test]
+    async fn successful_response_sets_cors_header() -> Result {
+        let app = App::new().route(WELL_KNOWN_PATH, web::get().to(webfinger_response));
+        let app = test::init_service(app).await;
+        let request = test::TestRequest::get().uri(WELL_KNOWN_PATH).to_request();
+
+        let response = test::call_service(&app, request).await;
+
+        assert_eq!(response.status(), StatusCode::OK, "{response:?}");
+        assert_eq!(
+            response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN),
+            Some(&CORS_ALLOW_ORIGIN_HEADER),
+        );
+        Ok(())
     }
 
     /// Accepts a percent-encoded `acct:` resource without panicking.

--- a/webfinger-rs/src/axum.rs
+++ b/webfinger-rs/src/axum.rs
@@ -3,7 +3,8 @@
 //! Enable the `axum` feature to:
 //!
 //! - extract [`WebFingerRequest`] from `GET` requests to [`crate::WELL_KNOWN_PATH`]; and
-//! - return [`WebFingerResponse`] directly from Axum handlers as `application/jrd+json`.
+//! - return [`WebFingerResponse`] directly from Axum handlers as `application/jrd+json` with the
+//!   WebFinger CORS header.
 //!
 //! The extractor expects the standard WebFinger query shape from [RFC 7033 section 4.1]:
 //!
@@ -44,16 +45,19 @@ use http::uri::InvalidUri;
 use http::{HeaderValue, StatusCode};
 use tracing::trace;
 
+use crate::http::CORS_ALLOW_ORIGIN;
 use crate::query::{RequestParams, RequestParamsError};
 use crate::{Rel, WebFingerRequest, WebFingerResponse};
 
 const JRD_CONTENT_TYPE: HeaderValue = HeaderValue::from_static("application/jrd+json");
+const CORS_ALLOW_ORIGIN_HEADER: HeaderValue = HeaderValue::from_static(CORS_ALLOW_ORIGIN);
 
 impl IntoResponse for WebFingerResponse {
     /// Converts a [`WebFingerResponse`] into an Axum response.
     ///
-    /// This serializes the body as JSON and sets the `Content-Type` header to
-    /// `application/jrd+json`, which is the JRD media type used by WebFinger.
+    /// This serializes the body as JSON, sets the `Content-Type` header to
+    /// `application/jrd+json`, and allows cross-origin browser requests with
+    /// `Access-Control-Allow-Origin: *` as recommended by RFC 7033 section 5.
     ///
     /// Handlers can therefore return [`WebFingerResponse`] directly without manually wrapping it in
     /// [`axum::Json`] or setting the response header themselves.
@@ -93,7 +97,17 @@ impl IntoResponse for WebFingerResponse {
     /// [Axum example]:
     ///     https://github.com/joshka/webfinger-rs/blob/main/webfinger-rs/examples/axum.rs
     fn into_response(self) -> AxumResponse {
-        ([(header::CONTENT_TYPE, JRD_CONTENT_TYPE)], Json(self)).into_response()
+        (
+            [
+                (header::CONTENT_TYPE, JRD_CONTENT_TYPE),
+                (
+                    header::ACCESS_CONTROL_ALLOW_ORIGIN,
+                    CORS_ALLOW_ORIGIN_HEADER,
+                ),
+            ],
+            Json(self),
+        )
+            .into_response()
     }
 }
 
@@ -283,6 +297,27 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK, "{response:?}");
         let body = response.into_text().await?;
         assert_eq!(body, r#"{"subject":"acct:carol@example.com","links":[]}"#);
+        Ok(())
+    }
+
+    /// Includes the RFC 7033 CORS header on successful JRD responses.
+    ///
+    /// WebFinger resources must be queryable from browsers, and RFC 7033 section 5 recommends the
+    /// least restrictive `Access-Control-Allow-Origin` value for public WebFinger resources.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-5>.
+    #[tokio::test]
+    async fn successful_response_sets_cors_header() -> Result {
+        let uri = format!("https://example.com{WELL_KNOWN_PATH}?resource={VALID_RESOURCE}");
+        let request = Request::builder().uri(uri).body(Body::empty())?;
+
+        let response = app().oneshot(request).await?;
+
+        assert_eq!(response.status(), StatusCode::OK, "{response:?}");
+        assert_eq!(
+            response.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN),
+            Some(&CORS_ALLOW_ORIGIN_HEADER),
+        );
         Ok(())
     }
 

--- a/webfinger-rs/src/http.rs
+++ b/webfinger-rs/src/http.rs
@@ -6,6 +6,8 @@ use percent_encoding::{AsciiSet, utf8_percent_encode};
 
 use crate::{WELL_KNOWN_PATH, WebFingerRequest, WebFingerResponse};
 
+pub(crate) const CORS_ALLOW_ORIGIN: &str = "*";
+
 /// The set of values to percent encode
 ///
 /// Notably, this set does not include the `@`, `:`, `?`, and `/` characters which are allowed by
@@ -82,6 +84,7 @@ impl TryFrom<&WebFingerResponse> for http::Response<()> {
     fn try_from(_: &WebFingerResponse) -> Result<http::Response<()>, http::Error> {
         http::Response::builder()
             .header("Content-Type", "application/jrd+json")
+            .header("Access-Control-Allow-Origin", CORS_ALLOW_ORIGIN)
             .body(())
     }
 }


### PR DESCRIPTION
## Summary

- add `Access-Control-Allow-Origin: *` to first-party WebFinger server responses
- keep Axum and Actix responder behavior aligned
- cover successful responder output with focused adapter tests

## Why

RFC 7033 section 5 requires WebFinger server responses to include `Access-Control-Allow-Origin` so browser-based clients can query WebFinger resources. The RFC also recommends the least restrictive value for public WebFinger resources, so the built-in responders now emit `Access-Control-Allow-Origin: *` by default.

Deployments that need a tighter origin policy can still enforce that at the application or middleware layer, where broader service CORS policy belongs.

Reference: https://www.rfc-editor.org/rfc/rfc7033.html#section-5

## Validation

- `cargo fmt --all --check`
- `cargo test -p webfinger-rs --all-features`
- `cargo clippy --workspace --all-features --all-targets`
