### PR TITLE
fix: validate WebFinger server request routing

### DIFF
--- a/webfinger-rs/src/actix.rs
+++ b/webfinger-rs/src/actix.rs
@@ -2,7 +2,8 @@
 //!
 //! Enable the `actix` feature to:
 //!
-//! - extract [`WebFingerRequest`] from requests routed to [`crate::WELL_KNOWN_PATH`]; and
+//! - extract [`WebFingerRequest`] from handlers mounted for `GET` requests to
+//!   [`crate::WELL_KNOWN_PATH`]; and
 //! - return [`WebFingerResponse`] directly from Actix handlers as `application/jrd+json` with the
 //!   WebFinger CORS header.
 //!
@@ -26,6 +27,16 @@
 //! # let _ = app;
 //! # assert_eq!(WELL_KNOWN_PATH, "/.well-known/webfinger");
 //! ```
+//!
+//! The Actix router owns path and method matching. Mounting the handler with `web::get()` or
+//! `#[get]` at [`crate::WELL_KNOWN_PATH`] rejects other paths and non-`GET` methods before this
+//! extractor runs. The extractor itself validates the WebFinger request metadata available inside
+//! the handler: host, query parameters, percent encoding, and the `resource` URI.
+//!
+//! RFC 7033 requires HTTPS for WebFinger. Actix request metadata does not reliably identify the
+//! externally visible scheme when the application runs behind TLS termination or a reverse proxy, so
+//! this extractor does not enforce scheme. Configure TLS and forwarded-proto handling at your
+//! server or proxy boundary.
 //!
 //! If extraction fails, Actix returns `400 Bad Request` for missing or duplicated `resource`,
 //! missing host values, invalid percent encoding, or invalid resource URIs.
@@ -286,6 +297,50 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK, "{response:?}");
         let body = to_bytes(response.into_body()).await?;
         assert_eq!(body.as_ref(), b"acct:bad@example.org");
+        Ok(())
+    }
+
+    /// Relies on Actix routing to reject non-WebFinger paths before extraction.
+    ///
+    /// RFC 7033 sections 4 and 10.1 define `/.well-known/webfinger` as the WebFinger resource.
+    /// Path matching stays in the router so applications get normal Actix `404 Not Found` behavior.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4> and
+    /// <https://www.rfc-editor.org/rfc/rfc7033.html#section-10.1>.
+    #[actix_web::test]
+    async fn wrong_path_is_not_routed() -> Result {
+        let app = App::new().route(WELL_KNOWN_PATH, web::get().to(webfinger));
+        let app = test::init_service(app).await;
+        let request = test::TestRequest::get()
+            .uri("/webfinger?resource=acct%3Abad%40example.org")
+            .insert_header(("host", "example.org"))
+            .to_request();
+
+        let response = test::call_service(&app, request).await;
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND, "{response:?}");
+        Ok(())
+    }
+
+    /// Relies on Actix routing to reject non-`GET` requests before extraction.
+    ///
+    /// RFC 7033 section 4.2 specifies a `GET` request. Method matching stays in the router so
+    /// applications get normal Actix routing behavior for other methods.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.2>.
+    #[actix_web::test]
+    async fn wrong_method_is_not_routed() -> Result {
+        let app = App::new().route(WELL_KNOWN_PATH, web::get().to(webfinger));
+        let app = test::init_service(app).await;
+        let uri = format!("{WELL_KNOWN_PATH}?resource=acct%3Abad%40example.org");
+        let request = test::TestRequest::post()
+            .uri(&uri)
+            .insert_header(("host", "example.org"))
+            .to_request();
+
+        let response = test::call_service(&app, request).await;
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND, "{response:?}");
         Ok(())
     }
 

--- a/webfinger-rs/src/axum.rs
+++ b/webfinger-rs/src/axum.rs
@@ -2,7 +2,8 @@
 //!
 //! Enable the `axum` feature to:
 //!
-//! - extract [`WebFingerRequest`] from `GET` requests to [`crate::WELL_KNOWN_PATH`]; and
+//! - extract [`WebFingerRequest`] from handlers mounted for `GET` requests to
+//!   [`crate::WELL_KNOWN_PATH`]; and
 //! - return [`WebFingerResponse`] directly from Axum handlers as `application/jrd+json` with the
 //!   WebFinger CORS header.
 //!
@@ -24,6 +25,16 @@
 //! let app = Router::<()>::new().route(WELL_KNOWN_PATH, get(webfinger));
 //! # let _ = app;
 //! ```
+//!
+//! The Axum router owns path and method matching. Mounting the handler with `get` at
+//! [`crate::WELL_KNOWN_PATH`] rejects other paths and non-`GET` methods before this extractor runs.
+//! The extractor itself validates the WebFinger request metadata available inside the handler:
+//! host, query parameters, percent encoding, and the `resource` URI.
+//!
+//! RFC 7033 requires HTTPS for WebFinger. Axum request parts do not reliably identify the
+//! externally visible scheme when the application runs behind TLS termination or a reverse proxy, so
+//! this extractor does not enforce scheme. Configure TLS and forwarded-proto handling at your
+//! server or proxy boundary.
 //!
 //! If extraction fails, Axum receives [`Rejection`], which returns `400 Bad Request` with a plain
 //! text message for missing or duplicated `resource`, missing host values, invalid percent
@@ -229,7 +240,7 @@ impl<S: Send + Sync> FromRequestParts<S> for WebFingerRequest {
 mod tests {
     use axum::body::Body;
     use axum::routing::get;
-    use http::{Request, Response};
+    use http::{Method, Request, Response};
     use http_body_util::BodyExt;
     use tower::ServiceExt;
 
@@ -339,6 +350,50 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK, "{response:?}");
         let body = response.into_text().await?;
         assert_eq!(body, r#"{"subject":"acct:carol@example.com","links":[]}"#);
+        Ok(())
+    }
+
+    /// Relies on Axum routing to reject non-WebFinger paths before extraction.
+    ///
+    /// RFC 7033 sections 4 and 10.1 define `/.well-known/webfinger` as the WebFinger resource.
+    /// Path matching stays in the router so applications get normal Axum `404 Not Found` behavior.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4> and
+    /// <https://www.rfc-editor.org/rfc/rfc7033.html#section-10.1>.
+    #[tokio::test]
+    async fn wrong_path_is_not_routed() -> Result {
+        let request = Request::builder()
+            .uri(format!("/webfinger?resource={VALID_RESOURCE}"))
+            .header(HOST, "example.com")
+            .body(Body::empty())?;
+
+        let response = app().oneshot(request).await?;
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND, "{response:?}");
+        Ok(())
+    }
+
+    /// Relies on Axum routing to reject non-`GET` requests before extraction.
+    ///
+    /// RFC 7033 section 4.2 specifies a `GET` request. Method matching stays in the router so
+    /// applications get normal Axum `405 Method Not Allowed` behavior.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.2>.
+    #[tokio::test]
+    async fn wrong_method_is_not_routed() -> Result {
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri(format!("{WELL_KNOWN_PATH}?resource={VALID_RESOURCE}"))
+            .header(HOST, "example.com")
+            .body(Body::empty())?;
+
+        let response = app().oneshot(request).await?;
+
+        assert_eq!(
+            response.status(),
+            StatusCode::METHOD_NOT_ALLOWED,
+            "{response:?}"
+        );
         Ok(())
     }
 

--- a/webfinger-rs/src/lib.rs
+++ b/webfinger-rs/src/lib.rs
@@ -79,6 +79,14 @@
 //!
 //! See: [RFC 7033 section 4.1] for the query-construction rules and percent-encoding details.
 //!
+//! Server integrations split that contract across the normal web-framework boundary:
+//!
+//! - mount the handler as `GET` at [`WELL_KNOWN_PATH`] so the router rejects other paths and
+//!   methods;
+//! - configure TLS and forwarded-proto handling at the server or reverse-proxy boundary; and
+//! - let the [`crate::axum`] or [`crate::actix`] extractor validate the request host, query
+//!   parameters, percent encoding, and `resource` URI.
+//!
 //! A successful JRD response might look like this:
 //!
 //! ```json


### PR DESCRIPTION
## Summary

- document that Axum and Actix routers own WebFinger path and method matching
- document that TLS and forwarded-proto handling belongs at the server or proxy boundary
- add Axum and Actix route-behavior tests for wrong path and wrong method requests

## Validation

- `cargo fmt --all --check`
- `cargo test -p webfinger-rs --all-features`
- `cargo test --workspace`

## Notes

This keeps the extractor API unchanged. The extractor still validates the request metadata it sees
inside the handler: host, query parameters, percent encoding, and the `resource` URI.
