### PR TITLE
fix: validate WebFinger resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,28 @@ Current integration targets:
 - Axum `0.8`
 - Actix Web `4`
 
+## Protocol overview
+
+A WebFinger query is an HTTPS `GET` against `/.well-known/webfinger` with a required `resource`
+parameter and, optionally, one or more `rel` parameters. The `resource` parameter is the query
+target URI; builders and server extractors reject relative references such as `carol`,
+`/relative`, `../x`, and empty values.
+
+A request built by this crate today for `acct:carol@example.com` filtered to the profile-page
+relation looks like this:
+
+```text
+GET https://example.com/.well-known/webfinger?resource=acct:carol@example.com&rel=http://webfinger.net/rel/profile-page
+```
+
+Server integrations split that contract across the normal web-framework boundary:
+
+- mount the handler as `GET` at `/.well-known/webfinger` so the router rejects other paths and
+  methods;
+- configure TLS and forwarded-proto handling at the server or reverse-proxy boundary; and
+- let the Axum or Actix Web extractor validate the request host, query parameters, percent
+  encoding, and `resource` URI.
+
 ## Install
 
 Add the crate with the feature set you need:

--- a/webfinger-cli/src/main.rs
+++ b/webfinger-cli/src/main.rs
@@ -6,9 +6,8 @@ use clap_verbosity_flag::{InfoLevel, Verbosity};
 use color_eyre::Result;
 use color_eyre::eyre::{Context, bail};
 use colored_json::ToColoredJson;
-use http::Uri;
 use tracing::{debug, warn};
-use webfinger_rs::{Rel, WebFingerRequest};
+use webfinger_rs::{Rel, Resource, WebFingerRequest};
 
 /// A simple CLI for fetching webfinger resources
 #[derive(Debug, Parser)]
@@ -60,9 +59,10 @@ async fn main() -> Result<()> {
 
 impl FetchCommand {
     async fn execute(&self) -> Result<()> {
+        let resource = self.resource()?;
         let request = WebFingerRequest {
-            host: self.host()?,
-            resource: self.resource()?,
+            host: self.host(&resource)?,
+            resource,
             rels: self.link_relations(),
         };
         debug!("fetching webfinger resource: {:?}", request);
@@ -78,16 +78,15 @@ impl FetchCommand {
         Ok(())
     }
 
-    fn host(&self) -> Result<String> {
-        // TODO use correct normalization of host names
+    fn host(&self, resource: &Resource) -> Result<String> {
         if let Some(host) = self.host.as_deref() {
             Ok(host.to_string())
         } else {
-            let resource = self.resource()?;
             if let Some(host) = resource.host() {
                 debug!("extracted host from resource URI: {}", host);
                 Ok(host.to_string())
             } else if let Some((_, host)) = self.resource.split_once('@') {
+                // TODO normalize account-address hosts before constructing the request URI.
                 debug!("extracted host from acct resource: {}", host);
                 Ok(host.to_string())
             } else {
@@ -96,7 +95,7 @@ impl FetchCommand {
         }
     }
 
-    fn resource(&self) -> Result<Uri> {
+    fn resource(&self) -> Result<Resource> {
         self.resource.parse().wrap_err("invalid resource")
     }
 
@@ -128,8 +127,9 @@ mod tests {
     #[test]
     fn host_uses_resource_uri_authority() {
         let command = command("https://example.org/users/@carol");
+        let resource = command.resource().unwrap();
 
-        let host = command.host().unwrap();
+        let host = command.host(&resource).unwrap();
 
         assert_eq!(host, "example.org");
     }
@@ -143,8 +143,9 @@ mod tests {
     #[test]
     fn host_falls_back_to_acct_authority() {
         let command = command("acct:carol@example.org");
+        let resource = command.resource().unwrap();
 
-        let host = command.host().unwrap();
+        let host = command.host(&resource).unwrap();
 
         assert_eq!(host, "example.org");
     }

--- a/webfinger-rs/src/actix.rs
+++ b/webfinger-rs/src/actix.rs
@@ -12,6 +12,9 @@
 //! - a required `resource` query parameter; and
 //! - zero or more repeated `rel` query parameters.
 //!
+//! The `resource` value must be an absolute URI such as `acct:carol@example.com` or
+//! `https://example.com/users/carol`; relative references are rejected as malformed requests.
+//!
 //! In practice, route handlers should usually be mounted like this:
 //!
 //! ```rust
@@ -39,7 +42,8 @@
 //! server or proxy boundary.
 //!
 //! If extraction fails, Actix returns `400 Bad Request` for missing or duplicated `resource`,
-//! missing host values, invalid percent encoding, or invalid resource URIs.
+//! missing host values, invalid percent encoding, relative resource references, or invalid resource
+//! URIs.
 //!
 //! See also [`WebFingerRequest`] for the extractor impl, [`WebFingerResponse`] for the responder
 //! impl, and the [Actix example] for a runnable server.
@@ -177,15 +181,11 @@ fn extract_request(req: &HttpRequest) -> Result<WebFingerRequest, ActixError> {
         .or_else(|| req.headers().get("host").and_then(|h| h.to_str().ok()))
         .map(|h| h.to_string())
         .ok_or(ErrorBadRequest("missing host"))?;
-    let query = req.query_string().parse::<RequestParams>()?;
-    let resource = query
-        .resource
-        .parse()
-        .map_err(|error| ErrorBadRequest(format!("invalid resource: {error}")))?;
+    let query: RequestParams = req.query_string().parse()?;
     let rels = query.rel.into_iter().map(Rel::from).collect();
     Ok(WebFingerRequest {
         host,
-        resource,
+        resource: query.resource,
         rels,
     })
 }
@@ -365,6 +365,34 @@ mod tests {
         assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{response:?}");
         let body = to_bytes(response.into_body()).await?;
         assert_eq!(body.as_ref(), b"invalid resource: invalid authority");
+        Ok(())
+    }
+
+    /// Rejects relative resource references at the Actix extractor boundary.
+    ///
+    /// RFC 7033 identifies the WebFinger query target as a URI, not a relative reference. Actix
+    /// handlers should not receive ambiguous targets such as local paths or bare names.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.1> and
+    /// <https://www.rfc-editor.org/rfc/rfc3986.html#section-4.1>.
+    #[actix_web::test]
+    async fn relative_resource_is_bad_request() -> Result {
+        let app = App::new().route(WELL_KNOWN_PATH, web::get().to(webfinger));
+        let app = test::init_service(app).await;
+        let uri = format!("{WELL_KNOWN_PATH}?resource=/relative");
+        let request = test::TestRequest::get()
+            .uri(&uri)
+            .insert_header(("host", "example.org"))
+            .to_request();
+
+        let response = test::call_service(&app, request).await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{response:?}");
+        let body = to_bytes(response.into_body()).await?;
+        assert_eq!(
+            body.as_ref(),
+            b"invalid resource: resource must be an absolute URI",
+        );
         Ok(())
     }
 

--- a/webfinger-rs/src/axum.rs
+++ b/webfinger-rs/src/axum.rs
@@ -12,6 +12,9 @@
 //! - a required `resource` query parameter; and
 //! - zero or more `rel` query parameters, encoded as repeated keys rather than a list.
 //!
+//! The `resource` value must be an absolute URI such as `acct:carol@example.com` or
+//! `https://example.com/users/carol`; relative references are rejected as malformed requests.
+//!
 //! In practice, route handlers should usually be mounted like this:
 //!
 //! ```rust
@@ -38,7 +41,7 @@
 //!
 //! If extraction fails, Axum receives [`Rejection`], which returns `400 Bad Request` with a plain
 //! text message for missing or duplicated `resource`, missing host values, invalid percent
-//! encoding, or invalid resource URIs.
+//! encoding, relative resource references, or invalid resource URIs.
 //!
 //! See also [`WebFingerRequest`] for the extractor impl, [`WebFingerResponse`] for the responder
 //! impl, and the [Axum example] for a runnable server.
@@ -52,13 +55,12 @@ use axum::extract::FromRequestParts;
 use axum::response::{IntoResponse, Response as AxumResponse};
 use http::header::{self, HOST};
 use http::request::Parts;
-use http::uri::InvalidUri;
 use http::{HeaderValue, StatusCode};
 use tracing::trace;
 
 use crate::http::CORS_ALLOW_ORIGIN;
 use crate::query::{RequestParams, RequestParamsError};
-use crate::{Rel, WebFingerRequest, WebFingerResponse};
+use crate::{Rel, ResourceError, WebFingerRequest, WebFingerResponse};
 
 const JRD_CONTENT_TYPE: HeaderValue = HeaderValue::from_static("application/jrd+json");
 const CORS_ALLOW_ORIGIN_HEADER: HeaderValue = HeaderValue::from_static(CORS_ALLOW_ORIGIN);
@@ -132,18 +134,18 @@ impl IntoResponse for WebFingerResponse {
 /// - [`Rejection::MissingHost`] when neither the request URI nor the `Host` header provides an
 ///   authority;
 /// - [`Rejection::InvalidQueryString`] when the query string is missing `resource`, contains more
-///   than one `resource`, or contains malformed percent encoding; and
-/// - [`Rejection::InvalidResource`] when `resource` is present but cannot be parsed as an
-///   [`http::Uri`].
+///   than one `resource`, or contains malformed percent encoding;
+/// - [`Rejection::InvalidResource`] when the `resource` value is not an absolute URI.
+#[derive(Debug)]
 pub enum Rejection {
     /// The WebFinger query string is missing required data or is malformed.
     InvalidQueryString(String),
 
+    /// The `resource` query parameter is not an absolute URI.
+    InvalidResource(ResourceError),
+
     /// The `Host` header is missing.
     MissingHost,
-
-    /// The `resource` query parameter is invalid.
-    InvalidResource(InvalidUri),
 }
 
 impl IntoResponse for Rejection {
@@ -157,7 +159,7 @@ impl IntoResponse for Rejection {
         let message = match self {
             Rejection::MissingHost => "missing host".to_string(),
             Rejection::InvalidQueryString(error) => error,
-            Rejection::InvalidResource(e) => format!("invalid resource: {e}"),
+            Rejection::InvalidResource(error) => format!("invalid resource: {error}"),
         };
         (StatusCode::BAD_REQUEST, message).into_response()
     }
@@ -165,7 +167,10 @@ impl IntoResponse for Rejection {
 
 impl From<RequestParamsError> for Rejection {
     fn from(error: RequestParamsError) -> Self {
-        Rejection::InvalidQueryString(error.to_string())
+        match error {
+            RequestParamsError::InvalidResource(error) => Rejection::InvalidResource(error),
+            error => Rejection::InvalidQueryString(error.to_string()),
+        }
     }
 }
 
@@ -224,13 +229,12 @@ impl<S: Send + Sync> FromRequestParts<S> for WebFingerRequest {
             .map(str::to_string)
             .ok_or(Rejection::MissingHost)?;
 
-        let query = parts.uri.query().unwrap_or("").parse::<RequestParams>()?;
-        let resource = query.resource.parse().map_err(Rejection::InvalidResource)?;
+        let query: RequestParams = parts.uri.query().unwrap_or("").parse()?;
         let rels = query.rel.into_iter().map(Rel::from).collect();
 
         Ok(WebFingerRequest {
             host,
-            resource,
+            resource: query.resource,
             rels,
         })
     }
@@ -452,6 +456,38 @@ mod tests {
         assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{response:?}");
         let body = response.into_text().await?;
         assert_eq!(body, "invalid resource: invalid authority");
+        Ok(())
+    }
+
+    /// Preserves the typed resource parse error until Axum renders the rejection.
+    #[test]
+    fn invalid_resource_rejection_preserves_resource_error() {
+        let error = "resource=/relative".parse::<RequestParams>().unwrap_err();
+        let rejection = Rejection::from(error);
+
+        assert!(matches!(
+            rejection,
+            Rejection::InvalidResource(ResourceError::RelativeReference)
+        ));
+    }
+
+    /// Rejects relative resource references at the Axum extractor boundary.
+    ///
+    /// RFC 7033 identifies the WebFinger query target as a URI, not a relative reference. Axum
+    /// handlers should not receive ambiguous targets such as local paths or bare names.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.1> and
+    /// <https://www.rfc-editor.org/rfc/rfc3986.html#section-4.1>.
+    #[tokio::test]
+    async fn relative_resource_is_bad_request() -> Result {
+        let uri = format!("https://example.com{WELL_KNOWN_PATH}?resource=/relative");
+        let request = Request::builder().uri(uri).body(Body::empty())?;
+
+        let response = app().oneshot(request).await?;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{response:?}");
+        let body = response.into_text().await?;
+        assert_eq!(body, "invalid resource: resource must be an absolute URI");
         Ok(())
     }
 

--- a/webfinger-rs/src/error.rs
+++ b/webfinger-rs/src/error.rs
@@ -1,3 +1,5 @@
+use crate::ResourceError;
+
 /// Error type for this crate.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -15,4 +17,8 @@ pub enum Error {
     // Json(#[from] serde_json::Error),
     #[error("invalid uri: {0}")]
     InvalidUri(#[from] http::uri::InvalidUri),
+
+    /// A WebFinger resource is malformed.
+    #[error(transparent)]
+    InvalidResource(#[from] ResourceError),
 }

--- a/webfinger-rs/src/lib.rs
+++ b/webfinger-rs/src/lib.rs
@@ -68,7 +68,8 @@
 //!
 //! A WebFinger query is an HTTPS `GET` against the well-known endpoint
 //! [`WELL_KNOWN_PATH`] with a required `resource` parameter and, optionally, one or more `rel`
-//! parameters.
+//! parameters. The `resource` parameter is the query target URI; builders and server extractors
+//! reject relative references such as `carol`, `/relative`, `../x`, and empty values.
 //!
 //! A request built by this crate today for `acct:carol@example.com` filtered to the profile-page
 //! relation looks like this:
@@ -257,7 +258,7 @@
 
 pub use crate::error::Error;
 pub use crate::types::{
-    Link, LinkBuilder, Rel, Request as WebFingerRequest, RequestBuilder,
+    Link, LinkBuilder, Rel, Request as WebFingerRequest, RequestBuilder, Resource, ResourceError,
     Response as WebFingerResponse, ResponseBuilder, Title,
 };
 

--- a/webfinger-rs/src/query.rs
+++ b/webfinger-rs/src/query.rs
@@ -5,17 +5,20 @@ use std::str::FromStr;
 use percent_encoding::percent_decode_str;
 use thiserror::Error;
 
+use crate::{Resource, ResourceError};
+
 /// The query parameters for a WebFinger request.
 ///
-/// `resource` is required exactly once by RFC 7033 sections 4.1 and 4.2, while `rel` may be
-/// repeated to filter the response to one or more relation types.
+/// `resource` is required exactly once by RFC 7033 sections 4.1 and 4.2 and must be an absolute
+/// URI rather than a relative reference. `rel` may be repeated to filter the response to one or
+/// more relation types.
 ///
 /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.1> and
 /// <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.2>.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct RequestParams {
     /// The decoded WebFinger resource query target.
-    pub(crate) resource: String,
+    pub(crate) resource: Resource,
 
     /// The decoded relation filters, preserving the client's repeated-key order.
     pub(crate) rel: Vec<String>,
@@ -52,7 +55,9 @@ impl FromStr for RequestParams {
             }
         }
 
-        let resource = resource.ok_or(RequestParamsError::MissingResource)?;
+        let resource = resource
+            .ok_or(RequestParamsError::MissingResource)?
+            .parse()?;
         Ok(RequestParams { resource, rel })
     }
 }
@@ -98,7 +103,7 @@ fn validate_percent_escapes(value: &str) -> Result<(), RequestParamsError> {
 }
 
 /// Errors that can occur while parsing WebFinger query parameters.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[derive(Debug, Error)]
 pub(crate) enum RequestParamsError {
     /// The required `resource` parameter is missing.
     #[error("missing resource parameter")]
@@ -111,6 +116,16 @@ pub(crate) enum RequestParamsError {
     /// A query parameter contains malformed percent encoding or invalid UTF-8 after decoding.
     #[error("invalid percent-encoded query parameter")]
     InvalidPercentEncoding,
+
+    /// The required `resource` parameter is not an absolute URI.
+    #[error("invalid resource: {0}")]
+    InvalidResource(ResourceError),
+}
+
+impl From<ResourceError> for RequestParamsError {
+    fn from(error: ResourceError) -> Self {
+        Self::InvalidResource(error)
+    }
 }
 
 #[cfg(test)]
@@ -126,14 +141,12 @@ mod tests {
     /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.1>.
     #[test]
     fn decodes_percent_encoded_resource() {
-        let query = "resource=acct%3Abad%40example.org"
-            .parse::<RequestParams>()
-            .unwrap();
+        let query: RequestParams = "resource=acct%3Abad%40example.org".parse().unwrap();
 
         assert_eq!(
             query,
             RequestParams {
-                resource: "acct:bad@example.org".to_string(),
+                resource: "acct:bad@example.org".parse().unwrap(),
                 rel: Vec::new(),
             },
         );
@@ -148,14 +161,13 @@ mod tests {
     /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.1>.
     #[test]
     fn preserves_repeated_rel_params() {
-        let query = "resource=acct%3Acarol%40example.org&rel=profile&rel=avatar"
-            .parse::<RequestParams>()
-            .unwrap();
+        const QUERY: &str = "resource=acct%3Acarol%40example.org&rel=profile&rel=avatar";
+        let query: RequestParams = QUERY.parse().unwrap();
 
         assert_eq!(
             query,
             RequestParams {
-                resource: "acct:carol@example.org".to_string(),
+                resource: "acct:carol@example.org".parse().unwrap(),
                 rel: vec!["profile".to_string(), "avatar".to_string()],
             },
         );
@@ -163,23 +175,22 @@ mod tests {
 
     /// Decodes percent-encoded relation URIs.
     ///
-    /// Relation filters are often URI strings. RFC 3986 section 2.1 percent encoding must be decoded
-    /// before handlers compare relation values, otherwise lookups see encoded text instead of the
-    /// requested relation.
+    /// Relation filters are often URI strings. RFC 3986 section 2.1 percent encoding must be
+    /// decoded before handlers compare relation values, otherwise lookups see encoded text
+    /// instead of the requested relation.
     ///
     /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.1> and
     /// <https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1>.
     #[test]
     fn decodes_percent_encoded_rel_params() {
         let rel = "http%3A%2F%2Fwebfinger.example%2Frel%2Fprofile-page";
-        let query = format!("resource=acct%3Acarol%40example.org&rel={rel}")
-            .parse::<RequestParams>()
-            .unwrap();
+        let query_string = format!("resource=acct%3Acarol%40example.org&rel={rel}");
+        let query: RequestParams = query_string.parse().unwrap();
 
         assert_eq!(
             query,
             RequestParams {
-                resource: "acct:carol@example.org".to_string(),
+                resource: "acct:carol@example.org".parse().unwrap(),
                 rel: vec!["http://webfinger.example/rel/profile-page".to_string()],
             },
         );
@@ -187,52 +198,56 @@ mod tests {
 
     /// Rejects percent-decoded values that are not valid UTF-8.
     ///
-    /// The parser returns owned Rust strings, so RFC 3986 percent-encoded bytes that do not decode to
-    /// UTF-8 must fail before they can become replacement characters or handler-visible data.
+    /// The parser returns owned Rust strings, so RFC 3986 percent-encoded bytes that do not decode
+    /// to UTF-8 must fail before they can become replacement characters or handler-visible
+    /// data.
     ///
     /// See <https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1>.
     #[test]
     fn rejects_invalid_utf8_percent_encoded_values() {
-        let error = "resource=acct%3Acarol%40example.org&rel=%FF"
-            .parse::<RequestParams>()
-            .unwrap_err();
+        const QUERY: &str = "resource=acct%3Acarol%40example.org&rel=%FF";
+        let error = QUERY.parse::<RequestParams>().unwrap_err();
 
-        assert_eq!(error, RequestParamsError::InvalidPercentEncoding);
+        assert!(
+            matches!(error, RequestParamsError::InvalidPercentEncoding),
+            "expected invalid-percent-encoding error, got {error:?}",
+        );
     }
 
     /// Rejects malformed percent escape syntax.
     ///
-    /// Some percent decoders leave invalid escapes like `%GG` unchanged. RFC 3986 section 2.1 defines
-    /// percent encoding as `%` followed by two hexadecimal digits, so the parser rejects malformed
-    /// escapes before decoding.
+    /// Some percent decoders leave invalid escapes like `%GG` unchanged. RFC 3986 section 2.1
+    /// defines percent encoding as `%` followed by two hexadecimal digits, so the parser
+    /// rejects malformed escapes before decoding.
     ///
     /// See <https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1>.
     #[test]
     fn rejects_malformed_percent_escape_syntax() {
-        let error = "resource=acct%3Acarol%40example.org&rel=%GG"
-            .parse::<RequestParams>()
-            .unwrap_err();
+        const QUERY: &str = "resource=acct%3Acarol%40example.org&rel=%GG";
+        let error = QUERY.parse::<RequestParams>().unwrap_err();
 
-        assert_eq!(error, RequestParamsError::InvalidPercentEncoding);
+        assert!(
+            matches!(error, RequestParamsError::InvalidPercentEncoding),
+            "expected invalid-percent-encoding error, got {error:?}",
+        );
     }
 
     /// Accepts `resource` in any query parameter position.
     ///
     /// RFC 7033 section 4.1 defines parameter names but not an order. This prevents order-sensitive
-    /// parsing where optional `rel` filters or extension parameters before `resource` break otherwise
-    /// valid requests.
+    /// parsing where optional `rel` filters or extension parameters before `resource` break
+    /// otherwise valid requests.
     ///
     /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.1>.
     #[test]
     fn resource_parameter_order_does_not_matter() {
-        let query = "rel=profile&resource=acct%3Acarol%40example.org"
-            .parse::<RequestParams>()
-            .unwrap();
+        const QUERY: &str = "rel=profile&resource=acct%3Acarol%40example.org";
+        let query: RequestParams = QUERY.parse().unwrap();
 
         assert_eq!(
             query,
             RequestParams {
-                resource: "acct:carol@example.org".to_string(),
+                resource: "acct:carol@example.org".parse().unwrap(),
                 rel: vec!["profile".to_string()],
             },
         );
@@ -248,14 +263,13 @@ mod tests {
     #[test]
     fn encoded_delimiters_stay_inside_resource() {
         let resource = "https%3A%2F%2Fexample.org%2Fprofile%3Fa%3D1%26b%3D2";
-        let query = format!("resource={resource}")
-            .parse::<RequestParams>()
-            .unwrap();
+        let query_string = format!("resource={resource}");
+        let query: RequestParams = query_string.parse().unwrap();
 
         assert_eq!(
             query,
             RequestParams {
-                resource: "https://example.org/profile?a=1&b=2".to_string(),
+                resource: "https://example.org/profile?a=1&b=2".parse().unwrap(),
                 rel: Vec::new(),
             },
         );
@@ -270,14 +284,13 @@ mod tests {
     /// See <https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1>.
     #[test]
     fn decodes_encoded_percent_once() {
-        let query = "resource=https://example.org/profile/a%2520b"
-            .parse::<RequestParams>()
-            .unwrap();
+        const QUERY: &str = "resource=https://example.org/profile/a%2520b";
+        let query: RequestParams = QUERY.parse().unwrap();
 
         assert_eq!(
             query,
             RequestParams {
-                resource: "https://example.org/profile/a%20b".to_string(),
+                resource: "https://example.org/profile/a%20b".parse().unwrap(),
                 rel: Vec::new(),
             },
         );
@@ -291,14 +304,12 @@ mod tests {
     /// See <https://www.rfc-editor.org/rfc/rfc3986.html#section-3.4>.
     #[test]
     fn plus_is_not_decoded_as_space() {
-        let query = "resource=acct%3Acarol+tag%40example.org"
-            .parse::<RequestParams>()
-            .unwrap();
+        let query: RequestParams = "resource=acct%3Acarol+tag%40example.org".parse().unwrap();
 
         assert_eq!(
             query,
             RequestParams {
-                resource: "acct:carol+tag@example.org".to_string(),
+                resource: "acct:carol+tag@example.org".parse().unwrap(),
                 rel: Vec::new(),
             },
         );
@@ -312,23 +323,58 @@ mod tests {
     /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.2>.
     #[test]
     fn rejects_multiple_resource_params() {
-        let error = "resource=acct%3Acarol%40example.org&resource=acct%3Aalice%40example.org"
-            .parse::<RequestParams>()
-            .unwrap_err();
+        const QUERY: &str =
+            "resource=acct%3Acarol%40example.org&resource=acct%3Aalice%40example.org";
+        let error = QUERY.parse::<RequestParams>().unwrap_err();
 
-        assert_eq!(error, RequestParamsError::MultipleResources);
+        assert!(
+            matches!(error, RequestParamsError::MultipleResources),
+            "expected multiple-resources error, got {error:?}",
+        );
     }
 
     /// Rejects requests that omit the required `resource` parameter.
     ///
     /// RFC 7033 section 4.2 treats absent `resource` parameters as bad requests. This keeps adapter
-    /// code from inventing a default target or depending on framework-specific deserialization errors.
+    /// code from inventing a default target or depending on framework-specific deserialization
+    /// errors.
     ///
     /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.2>.
     #[test]
     fn rejects_missing_resource_param() {
         let error = "rel=profile".parse::<RequestParams>().unwrap_err();
 
-        assert_eq!(error, RequestParamsError::MissingResource);
+        assert!(
+            matches!(error, RequestParamsError::MissingResource),
+            "expected missing-resource error, got {error:?}",
+        );
+    }
+
+    /// Rejects relative references in the `resource` parameter.
+    ///
+    /// RFC 7033 section 4.1 says the WebFinger query target is a URI. RFC 3986 distinguishes a URI
+    /// from a relative reference by the required scheme, so values like `carol`, `/relative`,
+    /// `../x`, and the empty string are malformed WebFinger resources.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.1> and
+    /// <https://www.rfc-editor.org/rfc/rfc3986.html#section-4.1>.
+    #[test]
+    fn rejects_relative_resource_references() {
+        for query in [
+            "resource=carol",
+            "resource=/relative",
+            "resource=../x",
+            "resource=",
+        ] {
+            let error = query.parse::<RequestParams>().unwrap_err();
+
+            assert!(
+                matches!(
+                    error,
+                    RequestParamsError::InvalidResource(ResourceError::RelativeReference)
+                ),
+                "expected relative-resource error, got {error:?}",
+            );
+        }
     }
 }

--- a/webfinger-rs/src/types.rs
+++ b/webfinger-rs/src/types.rs
@@ -1,7 +1,9 @@
 pub use rel::Rel;
 pub use request::{Builder as RequestBuilder, Request};
+pub use resource::{Resource, ResourceError};
 pub use response::{Builder as ResponseBuilder, Link, LinkBuilder, Response, Title};
 
 mod rel;
 mod request;
+mod resource;
 mod response;

--- a/webfinger-rs/src/types/rel.rs
+++ b/webfinger-rs/src/types/rel.rs
@@ -16,6 +16,9 @@ use nutype::nutype;
     AsRef,
     Deref,
     PartialEq,
+    PartialOrd,
     Eq,
+    Ord,
+    Hash,
 ))]
 pub struct Rel(String);

--- a/webfinger-rs/src/types/request.rs
+++ b/webfinger-rs/src/types/request.rs
@@ -1,8 +1,7 @@
-use http::Uri;
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as};
 
-use crate::{Error, Rel};
+use crate::{Error, Rel, Resource};
 
 /// A WebFinger request.
 ///
@@ -40,8 +39,10 @@ use crate::{Error, Rel};
 /// resources, set `host` to the domain that serves WebFinger for that account. In the common case,
 /// that is the same domain that appears after `@` in the `acct:` URI.
 ///
-/// `acct:` resources should include the full account URI, such as
-/// `acct:carol@example.com`, not just `carol@example.com` or `@carol@example.com`.
+/// `resource` must be an absolute URI, not a relative reference. `acct:` resources should include
+/// the full account URI, such as `acct:carol@example.com`, not just `carol@example.com` or
+/// `@carol@example.com`. Hierarchical URIs such as `https://example.com/users/carol` are also
+/// accepted.
 ///
 /// Repeated relation filters are encoded as repeated `rel` query parameters rather than as a
 /// comma-separated list.
@@ -89,21 +90,21 @@ use crate::{Error, Rel};
 /// }
 /// ```
 #[serde_as]
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Request {
     /// Query target.
     ///
-    /// This is the URI of the resource to query. It will be stored in the `resource` query
-    /// parameter.
+    /// This is the absolute URI of the resource to query. It will be stored in the `resource`
+    /// query parameter.
     ///
     /// For account lookups, use the full `acct:` URI, for example `acct:carol@example.com`.
+    /// Relative references such as `carol`, `/relative`, `../x`, and empty values are rejected by
+    /// builders and first-party server extractors.
     ///
     /// See: [RFC 7565 section 3](https://www.rfc-editor.org/rfc/rfc7565.html#section-3).
     ///
-    /// TODO: This could be a newtype that represents the resource and makes it easier to extract
-    /// the values / parse into the right types (e.g. `acct:` URIs).
     #[serde_as(as = "DisplayFromStr")]
-    pub resource: Uri,
+    pub resource: Resource,
 
     /// The host to query.
     ///
@@ -131,7 +132,10 @@ pub struct Request {
 
 impl Request {
     /// Creates a new WebFinger request.
-    pub fn new(resource: Uri) -> Self {
+    ///
+    /// This low-level constructor accepts an already validated [`Resource`]. Use
+    /// [`Request::builder`] or `str::parse::<Resource>()` when accepting untrusted resource text.
+    pub fn new(resource: Resource) -> Self {
         Self {
             host: String::new(),
             resource,
@@ -142,8 +146,8 @@ impl Request {
     /// Creates a new [`Builder`] for a WebFinger request.
     pub fn builder<U>(uri: U) -> Result<Builder, Error>
     where
-        Uri: TryFrom<U>,
-        <Uri as TryFrom<U>>::Error: Into<Error>,
+        Resource: TryFrom<U>,
+        <Resource as TryFrom<U>>::Error: Into<Error>,
     {
         Builder::new(uri)
     }
@@ -164,7 +168,7 @@ impl Request {
 ///     .build();
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Builder {
     request: Request,
 }
@@ -174,21 +178,23 @@ impl Builder {
     ///
     /// This will use the given URI as the resource for the query.
     ///
-    /// For account lookups, pass the complete `acct:` URI, such as `acct:carol@example.com`.
+    /// The resource must be an absolute URI with a scheme. For account lookups, pass the complete
+    /// `acct:` URI, such as `acct:carol@example.com`.
     ///
     /// See: [RFC 7565 section 3](https://www.rfc-editor.org/rfc/rfc7565.html#section-3).
     ///
     /// # Errors
     ///
-    /// This will return an error if the URI is invalid.
+    /// This will return an error if the URI is invalid or if it is a relative reference rather than
+    /// an absolute URI.
     pub fn new<U>(uri: U) -> Result<Self, Error>
     where
-        Uri: TryFrom<U>,
-        <Uri as TryFrom<U>>::Error: Into<Error>,
+        Resource: TryFrom<U>,
+        <Resource as TryFrom<U>>::Error: Into<Error>,
     {
-        TryFrom::try_from(uri)
-            .map(|uri| Self {
-                request: Request::new(uri),
+        Resource::try_from(uri)
+            .map(|resource| Self {
+                request: Request::new(resource),
             })
             .map_err(Into::into)
     }

--- a/webfinger-rs/src/types/resource.rs
+++ b/webfinger-rs/src/types/resource.rs
@@ -1,0 +1,255 @@
+use std::fmt;
+use std::str::FromStr;
+
+use http::Uri;
+
+/// Errors that can occur while parsing a WebFinger resource URI.
+#[non_exhaustive]
+#[derive(Debug, thiserror::Error)]
+pub enum ResourceError {
+    /// The resource is a relative reference instead of an absolute URI.
+    #[error("resource must be an absolute URI")]
+    RelativeReference,
+
+    /// The resource contains bytes outside the URI character set.
+    #[error("resource contains invalid URI characters")]
+    InvalidCharacters,
+
+    /// The resource contains a malformed percent escape.
+    #[error("resource contains invalid percent encoding")]
+    InvalidPercentEncoding,
+
+    /// The resource is an invalid HTTP or HTTPS URI.
+    #[error(transparent)]
+    InvalidHttpUri(#[from] http::uri::InvalidUri),
+}
+
+/// A WebFinger resource URI.
+///
+/// RFC 7033 uses the `resource` query parameter for the query target, which is a URI rather than a
+/// relative reference. `Resource` stores that URI text after checking that it has an RFC 3986
+/// scheme and contains only ASCII URI text. Hierarchical `http` and `https` resources are also
+/// parsed with [`http::Uri`] so malformed authorities are rejected.
+///
+/// Common valid resources include `acct:carol@example.com` and
+/// `https://example.org/users/carol`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Resource {
+    text: String,
+    host: Option<String>,
+}
+
+impl Resource {
+    /// Returns the resource URI as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.text
+    }
+
+    /// Returns the resource as an [`http::Uri`] when it fits that representation.
+    ///
+    /// WebFinger resources can use schemes such as `acct:` that are valid URI strings but do not
+    /// expose a host through [`http::Uri`]. This accessor is mainly useful for hierarchical
+    /// resources such as `https://example.org/users/carol`.
+    pub fn uri(&self) -> Option<Uri> {
+        Uri::try_from(self.as_str()).ok()
+    }
+
+    /// Returns the host from the resource's [`http::Uri`] representation, when present.
+    ///
+    /// URI schemes such as `acct:` do not have a host in [`http::Uri`], so this returns `None` for
+    /// those resources.
+    pub fn host(&self) -> Option<&str> {
+        self.host.as_deref()
+    }
+}
+
+impl fmt::Display for Resource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.text)
+    }
+}
+
+impl AsRef<str> for Resource {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl FromStr for Resource {
+    type Err = ResourceError;
+
+    fn from_str(resource: &str) -> Result<Self, Self::Err> {
+        let host = validate_resource(resource)?;
+        Ok(Self {
+            text: resource.to_string(),
+            host,
+        })
+    }
+}
+
+impl TryFrom<String> for Resource {
+    type Error = ResourceError;
+
+    fn try_from(resource: String) -> Result<Self, Self::Error> {
+        let host = validate_resource(&resource)?;
+        Ok(Self {
+            text: resource,
+            host,
+        })
+    }
+}
+
+impl TryFrom<&str> for Resource {
+    type Error = ResourceError;
+
+    fn try_from(resource: &str) -> Result<Self, Self::Error> {
+        resource.parse()
+    }
+}
+
+fn validate_resource(resource: &str) -> Result<Option<String>, ResourceError> {
+    let Some(scheme) = scheme(resource) else {
+        return Err(ResourceError::RelativeReference);
+    };
+    if !resource.is_ascii() {
+        return Err(ResourceError::InvalidCharacters);
+    }
+    if resource.bytes().any(|byte| byte <= b' ' || byte == 0x7f) {
+        return Err(ResourceError::InvalidCharacters);
+    }
+    validate_percent_escapes(resource)?;
+    if scheme.eq_ignore_ascii_case("http") || scheme.eq_ignore_ascii_case("https") {
+        let uri = Uri::try_from(resource).map_err(ResourceError::InvalidHttpUri)?;
+        return Ok(uri.host().map(str::to_string));
+    }
+    Ok(None)
+}
+
+fn validate_percent_escapes(resource: &str) -> Result<(), ResourceError> {
+    let mut bytes = resource.as_bytes().iter();
+    while let Some(byte) = bytes.next() {
+        if *byte != b'%' {
+            continue;
+        }
+        let Some(high) = bytes.next() else {
+            return Err(ResourceError::InvalidPercentEncoding);
+        };
+        let Some(low) = bytes.next() else {
+            return Err(ResourceError::InvalidPercentEncoding);
+        };
+        if !high.is_ascii_hexdigit() || !low.is_ascii_hexdigit() {
+            return Err(ResourceError::InvalidPercentEncoding);
+        }
+    }
+    Ok(())
+}
+
+fn scheme(resource: &str) -> Option<&str> {
+    let mut bytes = resource.bytes();
+    let first = bytes.next()?;
+    if !first.is_ascii_alphabetic() {
+        return None;
+    }
+
+    for (index, byte) in bytes.enumerate() {
+        match byte {
+            b':' => return Some(&resource[..index + 1]),
+            b'/' | b'?' | b'#' => return None,
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'+' | b'-' | b'.' => {}
+            _ => return None,
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Accepts `acct:` resources because they are absolute URIs with a scheme.
+    #[test]
+    fn accepts_acct_resource() {
+        let resource = "acct:carol@example.com".parse::<Resource>().unwrap();
+
+        assert_eq!(resource.as_str(), "acct:carol@example.com");
+    }
+
+    /// Accepts hierarchical HTTPS resources with an authority.
+    #[test]
+    fn accepts_https_resource() {
+        let resource = "https://example.org/users/carol"
+            .parse::<Resource>()
+            .unwrap();
+
+        assert_eq!(resource.as_str(), "https://example.org/users/carol");
+        assert_eq!(resource.host(), Some("example.org"));
+    }
+
+    /// Accepts scheme-specific opaque-looking URIs.
+    ///
+    /// RFC 3986's `URI` production requires a scheme but allows a scheme-specific path without an
+    /// authority. WebFinger commonly uses this shape for `acct:` resources.
+    #[test]
+    fn accepts_scheme_specific_resource() {
+        let resource = "urn:example:animal:ferret:nose"
+            .parse::<Resource>()
+            .unwrap();
+
+        assert_eq!(resource.as_str(), "urn:example:animal:ferret:nose");
+    }
+
+    /// Rejects relative references that `http::Uri` can otherwise parse.
+    #[test]
+    fn rejects_relative_resource_references() {
+        for resource in ["carol", "/relative", "../x", ""] {
+            let error = resource.parse::<Resource>().unwrap_err();
+
+            assert!(
+                matches!(error, ResourceError::RelativeReference),
+                "expected relative-resource error for {resource:?}, got {error:?}",
+            );
+        }
+    }
+
+    /// Rejects raw non-ASCII resource text.
+    ///
+    /// RFC 3986 URI syntax is ASCII. Non-ASCII data must be percent-encoded inside the resource URI
+    /// itself before it is put into the WebFinger query parameter.
+    #[test]
+    fn rejects_non_ascii_resource_text() {
+        let error = "acct:carolé@example.org".parse::<Resource>().unwrap_err();
+
+        assert!(
+            matches!(error, ResourceError::InvalidCharacters),
+            "expected invalid-character error, got {error:?}",
+        );
+    }
+
+    /// Rejects malformed percent escape syntax inside resource URIs.
+    ///
+    /// Percent escapes belong to the resource URI itself after the outer WebFinger query has been
+    /// decoded, so malformed escapes must be rejected at the resource boundary too.
+    #[test]
+    fn rejects_malformed_resource_percent_escape() {
+        let error = "acct:carol%GG@example.org".parse::<Resource>().unwrap_err();
+
+        assert!(
+            matches!(error, ResourceError::InvalidPercentEncoding),
+            "expected invalid-percent-encoding error, got {error:?}",
+        );
+    }
+
+    /// Validates HTTP and HTTPS resource authorities regardless of scheme case.
+    ///
+    /// URI schemes are case-insensitive, so uppercase `HTTPS` should not bypass the stricter
+    /// hierarchical URI validation used for HTTP resources.
+    #[test]
+    fn rejects_invalid_https_authority_with_uppercase_scheme() {
+        let error = "HTTPS://[::1".parse::<Resource>().unwrap_err();
+
+        assert!(
+            matches!(error, ResourceError::InvalidHttpUri(_)),
+            "expected invalid-authority error, got {error:?}",
+        );
+    }
+}

--- a/webfinger-rs/src/types/response.rs
+++ b/webfinger-rs/src/types/response.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::fmt::{self, Debug};
+use std::fmt;
 
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -53,7 +53,7 @@ use crate::Rel;
 /// }
 /// ```
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct Response {
     /// The subject of the response.
     ///
@@ -122,6 +122,7 @@ impl fmt::Display for Response {
 /// A builder for a WebFinger response.
 ///
 /// This is used to construct a [`Response`] with the desired fields.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Builder {
     response: Response,
 }
@@ -185,26 +186,11 @@ impl Builder {
     }
 }
 
-/// Custom debug implementation to avoid printing `None` fields
-impl Debug for Response {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut debug = f.debug_struct("Response");
-        let mut debug = debug.field("subject", &self.subject);
-        if let Some(aliases) = &self.aliases {
-            debug = debug.field("aliases", &aliases);
-        }
-        if let Some(properties) = &self.properties {
-            debug = debug.field("properties", &properties);
-        }
-        debug.field("links", &self.links).finish()
-    }
-}
-
 /// A link in the WebFinger response.
 ///
 /// Defined in [RFC 7033 Section 4.4](https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4)
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct Link {
     /// The relation type of the link.
     ///
@@ -258,6 +244,7 @@ impl Link {
 /// A builder for a WebFinger link.
 ///
 /// This is used to construct a [`Link`] with the desired fields.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LinkBuilder {
     link: Link,
 }
@@ -343,27 +330,6 @@ impl From<LinkBuilder> for Link {
     }
 }
 
-/// Custom debug implementation to avoid printing `None` fields
-impl Debug for Link {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut debug = f.debug_struct("Link");
-        let mut debug = debug.field("rel", &self.rel);
-        if let Some(r#type) = &self.r#type {
-            debug = debug.field("type", &r#type);
-        }
-        if let Some(href) = &self.href {
-            debug = debug.field("href", &href);
-        }
-        if let Some(titles) = &self.titles {
-            debug = debug.field("titles", &titles);
-        }
-        if let Some(properties) = &self.properties {
-            debug = debug.field("properties", &properties);
-        }
-        debug.finish()
-    }
-}
-
 /// A title in the WebFinger response.
 ///
 /// Defined in [RFC 7033 Section 4.4.4.4](https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.4)
@@ -375,7 +341,7 @@ impl Debug for Link {
 ///
 /// let title = Title::new("en-us", "Carol's Profile");
 /// ```
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Title {
     /// The language of the title.
     ///


### PR DESCRIPTION
## Summary

- add a validated Resource type for WebFinger query targets
- reject relative resource references in builders and first-party extractors
- preserve typed resource errors through query parsing and Axum rejection handling
- document the resource URI contract in Rustdoc and README

## Validation

- markdownlint-cli2 README.md
- cargo fmt --all --check
- cargo test --workspace
- cargo test --locked --all-features --doc