### PR TITLE
fix: validate WebFinger relation types

### DIFF
--- a/webfinger-cli/src/main.rs
+++ b/webfinger-cli/src/main.rs
@@ -63,7 +63,7 @@ impl FetchCommand {
         let request = WebFingerRequest {
             host: self.host(&resource)?,
             resource,
-            rels: self.link_relations(),
+            rels: self.link_relations()?,
         };
         debug!("fetching webfinger resource: {:?}", request);
         if self.insecure {
@@ -99,8 +99,12 @@ impl FetchCommand {
         self.resource.parse().wrap_err("invalid resource")
     }
 
-    fn link_relations(&self) -> Vec<Rel> {
-        self.rel.iter().map(|s| Rel::from(s.as_str())).collect()
+    fn link_relations(&self) -> Result<Vec<Rel>> {
+        self.rel
+            .iter()
+            .map(Rel::try_new)
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .wrap_err("invalid relation type")
     }
 }
 

--- a/webfinger-rs/src/actix.rs
+++ b/webfinger-rs/src/actix.rs
@@ -182,7 +182,12 @@ fn extract_request(req: &HttpRequest) -> Result<WebFingerRequest, ActixError> {
         .map(|h| h.to_string())
         .ok_or(ErrorBadRequest("missing host"))?;
     let query: RequestParams = req.query_string().parse()?;
-    let rels = query.rel.into_iter().map(Rel::from).collect();
+    let rels = query
+        .rel
+        .into_iter()
+        .map(Rel::try_new)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(ErrorBadRequest)?;
     Ok(WebFingerRequest {
         host,
         resource: query.resource,
@@ -449,6 +454,29 @@ mod tests {
             body.as_ref(),
             br#"["http://webfinger.example/rel/profile-page"]"#,
         );
+        Ok(())
+    }
+
+    /// Rejects relation values that are neither one registered relation type nor one URI.
+    ///
+    /// RFC 7033 section 4.4.4.1 allows one relation type per `rel` member. Multiple relation
+    /// filters should be encoded as repeated `rel` parameters, not as whitespace-separated values.
+    #[actix_web::test]
+    async fn invalid_rel_is_bad_request() -> Result {
+        let app = App::new().route(WELL_KNOWN_PATH, web::get().to(webfinger_rels));
+        let app = test::init_service(app).await;
+        let resource = "acct%3Acarol%40example.org";
+        let uri = format!("{WELL_KNOWN_PATH}?resource={resource}&rel=author%20avatar");
+        let request = test::TestRequest::get()
+            .uri(&uri)
+            .insert_header(("host", "example.org"))
+            .to_request();
+
+        let response = test::call_service(&app, request).await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{response:?}");
+        let body = to_bytes(response.into_body()).await?;
+        assert_eq!(body.as_ref(), b"invalid relation type: author avatar");
         Ok(())
     }
 

--- a/webfinger-rs/src/axum.rs
+++ b/webfinger-rs/src/axum.rs
@@ -60,7 +60,7 @@ use tracing::trace;
 
 use crate::http::CORS_ALLOW_ORIGIN;
 use crate::query::{RequestParams, RequestParamsError};
-use crate::{Rel, ResourceError, WebFingerRequest, WebFingerResponse};
+use crate::{Error, Rel, ResourceError, WebFingerRequest, WebFingerResponse};
 
 const JRD_CONTENT_TYPE: HeaderValue = HeaderValue::from_static("application/jrd+json");
 const CORS_ALLOW_ORIGIN_HEADER: HeaderValue = HeaderValue::from_static(CORS_ALLOW_ORIGIN);
@@ -135,7 +135,8 @@ impl IntoResponse for WebFingerResponse {
 ///   authority;
 /// - [`Rejection::InvalidQueryString`] when the query string is missing `resource`, contains more
 ///   than one `resource`, or contains malformed percent encoding;
-/// - [`Rejection::InvalidResource`] when the `resource` value is not an absolute URI.
+/// - [`Rejection::InvalidResource`] when the `resource` value is not an absolute URI; and
+/// - [`Rejection::InvalidRel`] when a `rel` value is not a URI or registered relation type.
 #[derive(Debug)]
 pub enum Rejection {
     /// The WebFinger query string is missing required data or is malformed.
@@ -143,6 +144,9 @@ pub enum Rejection {
 
     /// The `resource` query parameter is not an absolute URI.
     InvalidResource(ResourceError),
+
+    /// A `rel` query parameter is not a valid relation type.
+    InvalidRel(Error),
 
     /// The `Host` header is missing.
     MissingHost,
@@ -160,6 +164,7 @@ impl IntoResponse for Rejection {
             Rejection::MissingHost => "missing host".to_string(),
             Rejection::InvalidQueryString(error) => error,
             Rejection::InvalidResource(error) => format!("invalid resource: {error}"),
+            Rejection::InvalidRel(error) => error.to_string(),
         };
         (StatusCode::BAD_REQUEST, message).into_response()
     }
@@ -230,7 +235,12 @@ impl<S: Send + Sync> FromRequestParts<S> for WebFingerRequest {
             .ok_or(Rejection::MissingHost)?;
 
         let query: RequestParams = parts.uri.query().unwrap_or("").parse()?;
-        let rels = query.rel.into_iter().map(Rel::from).collect();
+        let rels = query
+            .rel
+            .into_iter()
+            .map(Rel::try_new)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Rejection::InvalidRel)?;
 
         Ok(WebFingerRequest {
             host,
@@ -553,6 +563,25 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK, "{response:?}");
         let body = response.into_text().await?;
         assert_eq!(body, r#"["http://webfinger.example/rel/profile-page"]"#);
+        Ok(())
+    }
+
+    /// Rejects relation values that are neither one registered relation type nor one URI.
+    ///
+    /// RFC 7033 section 4.4.4.1 allows one relation type per `rel` member. Multiple relation
+    /// filters should be encoded as repeated `rel` parameters, not as whitespace-separated values.
+    #[tokio::test]
+    async fn invalid_rel_is_bad_request() -> Result {
+        let resource = "acct%3Acarol%40example.org";
+        let uri =
+            format!("https://example.com{WELL_KNOWN_PATH}?resource={resource}&rel=author%20avatar");
+        let request = Request::builder().uri(uri).body(Body::empty())?;
+
+        let response = rels_app().oneshot(request).await?;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{response:?}");
+        let body = response.into_text().await?;
+        assert_eq!(body, "invalid relation type: author avatar");
         Ok(())
     }
 

--- a/webfinger-rs/src/error.rs
+++ b/webfinger-rs/src/error.rs
@@ -21,4 +21,8 @@ pub enum Error {
     /// A WebFinger resource is malformed.
     #[error(transparent)]
     InvalidResource(#[from] ResourceError),
+
+    /// A WebFinger relation type was not a URI or registered relation type.
+    #[error("invalid relation type: {0}")]
+    InvalidRel(String),
 }

--- a/webfinger-rs/src/http.rs
+++ b/webfinger-rs/src/http.rs
@@ -52,7 +52,7 @@ impl TryFrom<&WebFingerRequest> for PathAndQuery {
         path.push_str("?resource=");
         path.push_str(&resource);
         for rel in &query.rels {
-            let rel = utf8_percent_encode(rel, &QUERY).to_string();
+            let rel = utf8_percent_encode(rel.as_ref(), &QUERY).to_string();
             path.push_str("&rel=");
             path.push_str(&rel);
         }
@@ -130,7 +130,7 @@ mod tests {
         let request = WebFingerRequest {
             resource: "acct:carol@example.org".parse().unwrap(),
             host: "example.org".to_string(),
-            rels: vec![Rel::from("https://example.org/rel/a%2Fb")],
+            rels: vec![Rel::new("https://example.org/rel/a%2Fb")],
         };
 
         let uri = Uri::try_from(&request).unwrap();

--- a/webfinger-rs/src/types/rel.rs
+++ b/webfinger-rs/src/types/rel.rs
@@ -1,24 +1,282 @@
-use nutype::nutype;
+use std::borrow::Borrow;
+use std::fmt;
+use std::str::FromStr;
 
-/// Link relation type
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::Error;
+
+/// Link relation type.
 ///
-/// <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.1>
-#[nutype(derive(
-    Debug,
-    Display,
-    Clone,
-    From,
-    Into,
-    FromStr,
-    Display,
-    Serialize,
-    Deserialize,
-    AsRef,
-    Deref,
-    PartialEq,
-    PartialOrd,
-    Eq,
-    Ord,
-    Hash,
-))]
+/// WebFinger relation types are either absolute URI strings or IANA-registered relation type
+/// names. RFC 7033 requires each `rel` member to contain exactly one relation type, so this type
+/// rejects empty strings, relative URI references, and strings that try to carry multiple
+/// relation types.
+///
+/// `Rel` serializes as a JSON string and implements [`AsRef<str>`] for comparison or lookup
+/// without allocating. Builder methods accept strings for common use, but store this validated type
+/// so deserialized and programmatically built links use the same representation.
+///
+/// Registered relation type names use the `reg-rel-type` syntax from [RFC 5988 section 5.3].
+/// URI-valued relation types are validated as absolute URI strings.
+///
+/// See [RFC 7033 section 4.4.4.1].
+///
+/// # Examples
+///
+/// ```rust
+/// use webfinger_rs::Rel;
+///
+/// let registered = Rel::try_new("author")?;
+/// let uri = Rel::try_new("http://webfinger.net/rel/profile-page")?;
+///
+/// assert_eq!(registered.as_ref(), "author");
+/// assert_eq!(uri.as_ref(), "http://webfinger.net/rel/profile-page");
+/// # Ok::<(), webfinger_rs::Error>(())
+/// ```
+///
+/// Multiple relation types belong in multiple request `rel` parameters or multiple links, not in
+/// one `Rel` value:
+///
+/// ```rust
+/// use webfinger_rs::Rel;
+///
+/// assert!(Rel::try_new("author avatar").is_err());
+/// ```
+///
+/// [RFC 7033 section 4.4.4.1]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.1
+/// [RFC 5988 section 5.3]: https://www.rfc-editor.org/rfc/rfc5988.html#section-5.3
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Rel(String);
+
+impl Rel {
+    /// Creates a link relation type.
+    ///
+    /// This constructor is convenient for application-controlled relation strings. Use
+    /// [`Rel::try_new`] when parsing external input.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `rel` is not a URI relation type or registered relation type name. Use
+    /// [`Rel::try_new`] when handling untrusted input.
+    pub fn new<S: AsRef<str>>(rel: S) -> Self {
+        Self::try_new(rel).expect("invalid WebFinger link relation type")
+    }
+
+    /// Tries to create a link relation type.
+    ///
+    /// URI relation types must be absolute URI strings. Registered relation type names follow the
+    /// `reg-rel-type` syntax from RFC 5988: a lowercase ASCII letter followed by lowercase ASCII
+    /// letters, digits, `.`, or `-`.
+    pub fn try_new<S: AsRef<str>>(rel: S) -> Result<Self, Error> {
+        let rel = rel.as_ref();
+        if is_absolute_uri(rel) || is_registered_relation_type(rel) {
+            Ok(Self(rel.to_string()))
+        } else {
+            Err(Error::InvalidRel(rel.to_string()))
+        }
+    }
+}
+
+impl fmt::Display for Rel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl FromStr for Rel {
+    type Err = Error;
+
+    fn from_str(rel: &str) -> Result<Self, Self::Err> {
+        Self::try_new(rel)
+    }
+}
+
+impl TryFrom<&str> for Rel {
+    type Error = Error;
+
+    fn try_from(rel: &str) -> Result<Self, Self::Error> {
+        Self::try_new(rel)
+    }
+}
+
+impl TryFrom<String> for Rel {
+    type Error = Error;
+
+    fn try_from(rel: String) -> Result<Self, Self::Error> {
+        Self::try_new(rel)
+    }
+}
+
+impl From<Rel> for String {
+    fn from(rel: Rel) -> Self {
+        rel.0
+    }
+}
+
+impl AsRef<str> for Rel {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Borrow<str> for Rel {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Serialize for Rel {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for Rel {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(RelVisitor)
+    }
+}
+
+struct RelVisitor;
+
+impl Visitor<'_> for RelVisitor {
+    type Value = Rel;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a URI relation type or registered relation type")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Rel::try_new(value).map_err(E::custom)
+    }
+}
+
+fn is_absolute_uri(value: &str) -> bool {
+    let Ok(uri) = value.parse::<http::Uri>() else {
+        return false;
+    };
+    uri.scheme().is_some()
+}
+
+fn is_registered_relation_type(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    first.is_ascii_lowercase()
+        && chars.all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || matches!(ch, '.' | '-'))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+    use std::fmt::{Debug, Display};
+    use std::hash::Hash;
+
+    use serde::{Deserialize, Serialize};
+
+    use super::*;
+
+    fn assert_common_traits<T>()
+    where
+        T: Clone
+            + Debug
+            + Display
+            + Eq
+            + Ord
+            + Hash
+            + Send
+            + Sync
+            + Serialize
+            + for<'de> Deserialize<'de>,
+    {
+    }
+
+    #[test]
+    fn implements_applicable_common_traits() {
+        assert_common_traits::<Rel>();
+    }
+
+    #[test]
+    fn accepts_uri_relation_types() {
+        let rel = Rel::try_new("http://webfinger.net/rel/profile-page").unwrap();
+
+        assert_eq!(rel.as_ref(), "http://webfinger.net/rel/profile-page");
+    }
+
+    #[test]
+    fn accepts_registered_relation_types() {
+        let rel = Rel::try_new("author").unwrap();
+
+        assert_eq!(rel.as_ref(), "author");
+    }
+
+    #[test]
+    fn try_from_parses_valid_relation_types() {
+        let rel = Rel::try_from("author").unwrap();
+
+        assert_eq!(rel.as_ref(), "author");
+    }
+
+    #[test]
+    fn converts_back_into_owned_string() {
+        let rel = Rel::new("author");
+
+        assert_eq!(String::from(rel), "author");
+    }
+
+    #[test]
+    fn supports_borrowed_string_set_lookup() {
+        let mut values = BTreeSet::new();
+        values.insert(Rel::new("author"));
+
+        assert!(values.contains("author"));
+    }
+
+    #[test]
+    fn orders_by_relation_string() {
+        let first = Rel::new("author");
+        let second = Rel::new("http://webfinger.net/rel/profile-page");
+
+        assert!(first < second);
+    }
+
+    #[test]
+    fn rejects_empty_relation_types() {
+        let error = Rel::try_new("").expect_err("empty relation type");
+
+        assert!(error.to_string().contains("invalid relation type"));
+    }
+
+    #[test]
+    fn rejects_multiple_relation_types_in_one_value() {
+        let error = Rel::try_new("author avatar").expect_err("multiple relation types");
+
+        assert!(error.to_string().contains("invalid relation type"));
+    }
+
+    #[test]
+    fn rejects_relative_uri_relation_types() {
+        let error = Rel::try_new("/rel/profile-page").expect_err("relative URI relation type");
+
+        assert!(error.to_string().contains("invalid relation type"));
+    }
+
+    #[test]
+    fn deserialization_rejects_invalid_relation_types() {
+        let error = serde_json::from_str::<Rel>(r#""""#).expect_err("empty relation type");
+
+        assert!(error.to_string().contains("invalid relation type"));
+    }
+}

--- a/webfinger-rs/src/types/request.rs
+++ b/webfinger-rs/src/types/request.rs
@@ -225,8 +225,8 @@ impl Builder {
     ///     .build();
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn rel<R: Into<Rel>>(mut self, rel: R) -> Self {
-        self.request.rels.push(rel.into());
+    pub fn rel<R: AsRef<str>>(mut self, rel: R) -> Self {
+        self.request.rels.push(Rel::new(rel));
         self
     }
 
@@ -289,7 +289,7 @@ mod tests {
     #[test]
     fn example_3_1() {
         let resource = "acct:carol@example.com".parse().unwrap();
-        let rel = Rel::from("http://openid.net/specs/connect/1.0/issuer");
+        let rel = Rel::new("http://openid.net/specs/connect/1.0/issuer");
         let host = "example.com".parse().unwrap();
         let query = Request {
             host,

--- a/webfinger-rs/src/types/response.rs
+++ b/webfinger-rs/src/types/response.rs
@@ -236,7 +236,7 @@ impl Link {
     }
 
     /// Create a new [`LinkBuilder`] with the given relation type.
-    pub fn builder<R: Into<Rel>>(rel: R) -> LinkBuilder {
+    pub fn builder<R: AsRef<str>>(rel: R) -> LinkBuilder {
         LinkBuilder::new(rel)
     }
 }
@@ -251,9 +251,9 @@ pub struct LinkBuilder {
 
 impl LinkBuilder {
     /// Create a new link builder with the given relation type.
-    pub fn new<R: Into<Rel>>(rel: R) -> Self {
+    pub fn new<R: AsRef<str>>(rel: R) -> Self {
         Self {
-            link: Link::new(rel.into()),
+            link: Link::new(Rel::new(rel)),
         }
     }
 


### PR DESCRIPTION
## Summary

- replace free-form `Rel` construction with validation for registered relation names and absolute URI relation types
- reject malformed `rel` query values in CLI, Actix, and Axum request handling
- keep builder APIs ergonomic for string literals while preserving validated storage

## Validation

- `cargo fmt --all --check`
- `cargo test --workspace`
- `cargo test --locked --all-features --doc`
- `cargo clippy --workspace --all-features --all-targets`
