### PR TITLE
fix: align JRD response types

### DIFF
--- a/webfinger-rs/src/axum.rs
+++ b/webfinger-rs/src/axum.rs
@@ -60,7 +60,7 @@ use tracing::trace;
 
 use crate::http::CORS_ALLOW_ORIGIN;
 use crate::query::{RequestParams, RequestParamsError};
-use crate::{Error, Rel, ResourceError, WebFingerRequest, WebFingerResponse};
+use crate::{Rel, ResourceError, WebFingerRequest, WebFingerResponse};
 
 const JRD_CONTENT_TYPE: HeaderValue = HeaderValue::from_static("application/jrd+json");
 const CORS_ALLOW_ORIGIN_HEADER: HeaderValue = HeaderValue::from_static(CORS_ALLOW_ORIGIN);
@@ -135,8 +135,7 @@ impl IntoResponse for WebFingerResponse {
 ///   authority;
 /// - [`Rejection::InvalidQueryString`] when the query string is missing `resource`, contains more
 ///   than one `resource`, or contains malformed percent encoding;
-/// - [`Rejection::InvalidResource`] when the `resource` value is not an absolute URI; and
-/// - [`Rejection::InvalidRel`] when a `rel` value is not a URI or registered relation type.
+/// - [`Rejection::InvalidResource`] when the `resource` value is not an absolute URI.
 #[derive(Debug)]
 pub enum Rejection {
     /// The WebFinger query string is missing required data or is malformed.
@@ -145,11 +144,11 @@ pub enum Rejection {
     /// The `resource` query parameter is not an absolute URI.
     InvalidResource(ResourceError),
 
-    /// A `rel` query parameter is not a valid relation type.
-    InvalidRel(Error),
-
     /// The `Host` header is missing.
     MissingHost,
+
+    /// A `rel` query parameter is invalid.
+    InvalidRel(crate::Error),
 }
 
 impl IntoResponse for Rejection {
@@ -289,7 +288,7 @@ mod tests {
 
     /// Returns a minimal JRD response so tests can assert resource extraction through Axum.
     async fn webfinger(request: WebFingerRequest) -> impl IntoResponse {
-        WebFingerResponse::builder(request.resource.to_string()).build()
+        WebFingerResponse::builder(&request.resource).build()
     }
 
     /// Returns extracted relation filters so tests can assert RFC 7033 repeated `rel` handling.

--- a/webfinger-rs/src/error.rs
+++ b/webfinger-rs/src/error.rs
@@ -22,6 +22,10 @@ pub enum Error {
     #[error(transparent)]
     InvalidResource(#[from] ResourceError),
 
+    /// A WebFinger JRD field expected an absolute URI string.
+    #[error("invalid JRD URI: {0}")]
+    InvalidJrdUri(String),
+
     /// A WebFinger relation type was not a URI or registered relation type.
     #[error("invalid relation type: {0}")]
     InvalidRel(String),

--- a/webfinger-rs/src/lib.rs
+++ b/webfinger-rs/src/lib.rs
@@ -258,8 +258,8 @@
 
 pub use crate::error::Error;
 pub use crate::types::{
-    Link, LinkBuilder, Rel, Request as WebFingerRequest, RequestBuilder, Resource, ResourceError,
-    Response as WebFingerResponse, ResponseBuilder, Title,
+    JrdUri, Link, LinkBuilder, Rel, Request as WebFingerRequest, RequestBuilder, Resource,
+    ResourceError, Response as WebFingerResponse, ResponseBuilder, Title,
 };
 
 #[cfg(feature = "actix")]

--- a/webfinger-rs/src/types.rs
+++ b/webfinger-rs/src/types.rs
@@ -1,8 +1,32 @@
+//! WebFinger request and JRD response types.
+//!
+//! This module contains the Rust model for the protocol data described by RFC 7033:
+//!
+//! - [`Request`] models a WebFinger query from [RFC 7033 section 4.1].
+//! - [`Response`] models the JSON Resource Descriptor (JRD) response from
+//!   [RFC 7033 section 4.4].
+//! - [`JrdUri`] is used where the JRD grammar calls for URI strings, including `subject`,
+//!   `aliases`, `href`, and property identifiers.
+//! - [`Rel`] is used where RFC 7033 requires a single link relation type rather than arbitrary
+//!   text.
+//! - [`Link`] and [`LinkBuilder`] model link objects from [RFC 7033 section 4.4.4].
+//!
+//! The public crate root re-exports these types under the common `WebFingerRequest` and
+//! `WebFingerResponse` names, so most users can import from `webfinger_rs` directly.
+//!
+//! [RFC 7033 section 4.1]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.1
+//! [RFC 7033 section 4.4]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4
+//! [RFC 7033 section 4.4.4]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4
+
+pub use jrd_uri::JrdUri;
+pub use link::{Link, LinkBuilder, Title};
 pub use rel::Rel;
 pub use request::{Builder as RequestBuilder, Request};
 pub use resource::{Resource, ResourceError};
-pub use response::{Builder as ResponseBuilder, Link, LinkBuilder, Response, Title};
+pub use response::{Builder as ResponseBuilder, Response};
 
+mod jrd_uri;
+mod link;
 mod rel;
 mod request;
 mod resource;

--- a/webfinger-rs/src/types/jrd_uri.rs
+++ b/webfinger-rs/src/types/jrd_uri.rs
@@ -1,0 +1,276 @@
+use std::borrow::Borrow;
+use std::fmt;
+use std::str::FromStr;
+
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::Error;
+
+/// A URI string used in a WebFinger JRD response.
+///
+/// RFC 7033 defines the JRD `subject`, `aliases`, link `href`, and property identifiers as URI
+/// strings. This type keeps those fields distinct from free-form text and rejects relative URI
+/// references when values are parsed from JSON or constructed with [`JrdUri::try_new`].
+///
+/// `JrdUri` serializes as a JSON string, implements [`AsRef<str>`] for borrowed access, and can be
+/// converted back into a [`String`] when a caller needs owned text. Builder methods accept strings
+/// for ergonomics, then store validated `JrdUri` values internally.
+///
+/// See [RFC 7033 section 4.4.1] for `subject`, [section 4.4.2] for `aliases`,
+/// [section 4.4.3] for response properties, [section 4.4.4.3] for link `href`, and
+/// [section 4.4.4.5] for link properties.
+///
+/// # Examples
+///
+/// Fallible construction is useful when accepting input from users, configuration, or another
+/// service:
+///
+/// ```rust
+/// use webfinger_rs::JrdUri;
+///
+/// let subject = JrdUri::try_new("acct:carol@example.com")?;
+/// assert_eq!(subject.as_ref(), "acct:carol@example.com");
+/// # Ok::<(), webfinger_rs::Error>(())
+/// ```
+///
+/// Relative references are rejected:
+///
+/// ```rust
+/// use webfinger_rs::JrdUri;
+///
+/// assert!(JrdUri::try_new("/users/carol").is_err());
+/// ```
+///
+/// [RFC 7033 section 4.4.1]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.1
+/// [section 4.4.2]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.2
+/// [section 4.4.3]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.3
+/// [section 4.4.4.3]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.3
+/// [section 4.4.4.5]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.5
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct JrdUri(String);
+
+impl JrdUri {
+    /// Creates a JRD URI.
+    ///
+    /// This constructor is intended for URI strings controlled by the application, such as
+    /// constants and values already validated by routing or configuration code. Use
+    /// [`JrdUri::try_new`] for fallible construction from external input.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `uri` is not an absolute URI string. Use [`JrdUri::try_new`] when handling
+    /// untrusted input.
+    pub fn new<S: AsRef<str>>(uri: S) -> Self {
+        Self::try_new(uri).expect("invalid WebFinger JRD URI")
+    }
+
+    /// Tries to create a JRD URI from an absolute URI string.
+    ///
+    /// The value is stored without normalization. This preserves the string that will be serialized
+    /// into the JRD while still checking that callers did not pass relative references or ordinary
+    /// labels by mistake.
+    pub fn try_new<S: AsRef<str>>(uri: S) -> Result<Self, Error> {
+        let uri = uri.as_ref();
+        if is_absolute_uri(uri) {
+            Ok(Self(uri.to_string()))
+        } else {
+            Err(Error::InvalidJrdUri(uri.to_string()))
+        }
+    }
+}
+
+impl fmt::Display for JrdUri {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl fmt::Debug for JrdUri {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("JrdUri").field(&self.0).finish()
+    }
+}
+
+impl FromStr for JrdUri {
+    type Err = Error;
+
+    fn from_str(uri: &str) -> Result<Self, Self::Err> {
+        Self::try_new(uri)
+    }
+}
+
+impl TryFrom<&str> for JrdUri {
+    type Error = Error;
+
+    fn try_from(uri: &str) -> Result<Self, Self::Error> {
+        Self::try_new(uri)
+    }
+}
+
+impl TryFrom<String> for JrdUri {
+    type Error = Error;
+
+    fn try_from(uri: String) -> Result<Self, Self::Error> {
+        Self::try_new(uri)
+    }
+}
+
+impl From<JrdUri> for String {
+    fn from(uri: JrdUri) -> Self {
+        uri.0
+    }
+}
+
+impl AsRef<str> for JrdUri {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Borrow<str> for JrdUri {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Serialize for JrdUri {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for JrdUri {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(JrdUriVisitor)
+    }
+}
+
+struct JrdUriVisitor;
+
+impl Visitor<'_> for JrdUriVisitor {
+    type Value = JrdUri;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("an absolute URI string")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        JrdUri::try_new(value).map_err(E::custom)
+    }
+}
+
+pub(crate) fn is_absolute_uri(value: &str) -> bool {
+    let Some((scheme, _rest)) = value.split_once(':') else {
+        return false;
+    };
+    is_uri_scheme(scheme) && value.parse::<http::Uri>().is_ok()
+}
+
+fn is_uri_scheme(scheme: &str) -> bool {
+    let mut chars = scheme.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    first.is_ascii_alphabetic()
+        && chars.all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '+' | '-' | '.'))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::fmt::{Debug, Display};
+    use std::hash::Hash;
+
+    use serde::{Deserialize, Serialize};
+
+    use super::*;
+
+    fn assert_common_traits<T>()
+    where
+        T: Clone
+            + Debug
+            + Display
+            + Eq
+            + Ord
+            + Hash
+            + Send
+            + Sync
+            + Serialize
+            + for<'de> Deserialize<'de>,
+    {
+    }
+
+    #[test]
+    fn implements_applicable_common_traits() {
+        assert_common_traits::<JrdUri>();
+    }
+
+    #[test]
+    fn accepts_absolute_uri_strings() {
+        let uri = JrdUri::try_new("acct:carol@example.com").unwrap();
+
+        assert_eq!(uri.as_ref(), "acct:carol@example.com");
+    }
+
+    #[test]
+    fn try_from_parses_valid_uri_strings() {
+        let uri = JrdUri::try_from("acct:carol@example.com").unwrap();
+
+        assert_eq!(uri.as_ref(), "acct:carol@example.com");
+    }
+
+    #[test]
+    fn converts_back_into_owned_string() {
+        let uri = JrdUri::new("acct:carol@example.com");
+
+        assert_eq!(String::from(uri), "acct:carol@example.com");
+    }
+
+    #[test]
+    fn supports_borrowed_string_map_lookup() {
+        let mut values = BTreeMap::new();
+        values.insert(JrdUri::new("acct:carol@example.com"), "Carol");
+
+        assert_eq!(values.get("acct:carol@example.com"), Some(&"Carol"));
+    }
+
+    #[test]
+    fn orders_by_uri_string() {
+        let first = JrdUri::new("acct:alice@example.com");
+        let second = JrdUri::new("acct:carol@example.com");
+
+        assert!(first < second);
+    }
+
+    #[test]
+    fn rejects_relative_uri_references() {
+        let error = JrdUri::try_new("/profile/carol").expect_err("relative URI");
+
+        assert!(error.to_string().contains("invalid JRD URI"));
+    }
+
+    #[test]
+    fn rejects_non_uri_strings() {
+        let error = JrdUri::try_new("carol@example.com").expect_err("non-URI string");
+
+        assert!(error.to_string().contains("invalid JRD URI"));
+    }
+
+    #[test]
+    fn deserialization_rejects_relative_uri_references() {
+        let error =
+            serde_json::from_str::<JrdUri>(r#""/profile/carol""#).expect_err("relative URI");
+
+        assert!(error.to_string().contains("invalid JRD URI"));
+    }
+}

--- a/webfinger-rs/src/types/link.rs
+++ b/webfinger-rs/src/types/link.rs
@@ -1,0 +1,481 @@
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+use crate::{JrdUri, Rel};
+
+/// A link in the WebFinger response.
+///
+/// Link objects describe related resources for the JRD subject. RFC 7033 gives each link a
+/// required [`rel`](Self::rel) member and optional `type`, `href`, `titles`, and `properties`
+/// members.
+///
+/// The Rust fields mirror the JRD JSON shape:
+///
+/// - [`rel`](Self::rel) is a [`Rel`] so the required relation string is validated as one relation
+///   type.
+/// - [`href`](Self::href) is a [`JrdUri`] because RFC 7033 defines it as a URI string.
+/// - [`titles`](Self::titles) is a language-keyed object, matching the RFC JSON form.
+/// - [`properties`](Self::properties) uses [`JrdUri`] keys and `Option<String>` values so JSON
+///   `null` is representable.
+///
+/// Use [`Link::builder`] for ordinary construction from string literals or application values. Use
+/// [`Link::new`] when you already have a validated [`Rel`].
+///
+/// See [RFC 7033 section 4.4.4].
+///
+/// # Examples
+///
+/// ```rust
+/// use webfinger_rs::Link;
+///
+/// let link = Link::builder("http://webfinger.net/rel/profile-page")
+///     .href("https://example.com/profile/carol")
+///     .r#type("text/html")
+///     .title("en-us", "Carol's profile")
+///     .property("https://example.com/ns/verified", "true")
+///     .null_property("https://example.com/ns/old-profile")
+///     .build();
+///
+/// assert_eq!(link.rel.as_ref(), "http://webfinger.net/rel/profile-page");
+/// ```
+///
+/// [RFC 7033 section 4.4.4]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Link {
+    /// The relation type of the link.
+    ///
+    /// This member is required by [RFC 7033 section 4.4.4.1]. It uses [`Rel`] instead of `String`
+    /// so deserialization and builder construction both reject empty or malformed relation
+    /// values.
+    ///
+    /// [RFC 7033 section 4.4.4.1]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.1
+    pub rel: Rel,
+
+    /// The media type of the link.
+    ///
+    /// RFC 7033 leaves this as a media type string. The crate stores it as `String` because it is
+    /// advisory metadata for the linked representation, not one of the WebFinger URI-valued
+    /// fields.
+    ///
+    /// See [RFC 7033 section 4.4.4.2].
+    ///
+    /// [RFC 7033 section 4.4.4.2]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.2
+    pub r#type: Option<String>,
+
+    /// The target URI of the link.
+    ///
+    /// RFC 7033 defines `href` as a URI string. The field uses [`JrdUri`] rather than `String` so
+    /// relative references are rejected when links are deserialized or built through the builder.
+    ///
+    /// See [RFC 7033 section 4.4.4.3].
+    ///
+    /// [RFC 7033 section 4.4.4.3]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.3
+    pub href: Option<JrdUri>,
+
+    /// The titles of the link.
+    ///
+    /// RFC 7033 models titles as a JSON object whose keys are language tags and whose values are
+    /// title strings. The crate uses a `BTreeMap` so direct struct construction preserves that JSON
+    /// object shape and gets deterministic ordering for comparisons, hashing, and rendered output.
+    ///
+    /// Use [`LinkBuilder::title`] for one title at a time or [`LinkBuilder::titles`] to set a full
+    /// language map.
+    ///
+    /// See [RFC 7033 section 4.4.4.4].
+    ///
+    /// [RFC 7033 section 4.4.4.4]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.4
+    pub titles: Option<BTreeMap<String, String>>,
+
+    /// The properties of the link.
+    ///
+    /// Link properties are a JSON object whose property identifiers are URI strings. Values may be
+    /// strings or JSON `null`, so the Rust value type is `Option<String>`. `None` serializes as a
+    /// property value of `null`; it does not omit the property from the map.
+    ///
+    /// Use [`LinkBuilder::property`] for string-valued properties and
+    /// [`LinkBuilder::null_property`] for JSON `null` values.
+    ///
+    /// See [RFC 7033 section 4.4.4.5].
+    ///
+    /// [RFC 7033 section 4.4.4.5]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.5
+    pub properties: Option<BTreeMap<JrdUri, Option<String>>>,
+}
+
+impl Link {
+    /// Creates a link from an already validated relation type.
+    ///
+    /// The returned link has no optional members set. This is useful when relation validation
+    /// happens separately, for example when reusing a [`Rel`] from a request filter. Use
+    /// [`Link::builder`] when constructing a link directly from strings.
+    pub fn new(rel: Rel) -> Self {
+        Self {
+            rel,
+            r#type: None,
+            href: None,
+            titles: None,
+            properties: None,
+        }
+    }
+
+    /// Creates a [`LinkBuilder`] with the given relation type.
+    ///
+    /// The builder accepts a string-like value for the common case and validates it into [`Rel`].
+    /// Invalid values panic through [`Rel::new`]; use [`Rel::try_new`] and [`Link::new`] when the
+    /// relation comes from untrusted input.
+    pub fn builder<R: AsRef<str>>(rel: R) -> LinkBuilder {
+        LinkBuilder::new(rel)
+    }
+}
+
+/// A builder for a WebFinger link.
+///
+/// `LinkBuilder` keeps common JRD construction concise while preserving the typed representation
+/// used by [`Link`]. String arguments are accepted at the method boundary and converted into
+/// [`Rel`] or [`JrdUri`] where the RFC requires those shapes.
+///
+/// The builder can be passed directly to [`ResponseBuilder::link`](crate::ResponseBuilder::link)
+/// because `Link` implements `From<LinkBuilder>`.
+///
+/// # Examples
+///
+/// ```rust
+/// use webfinger_rs::{Link, WebFingerResponse};
+///
+/// let response = WebFingerResponse::builder("acct:carol@example.com")
+///     .link(
+///         Link::builder("author")
+///             .href("https://example.com/people/carol")
+///             .title("en-us", "Carol"),
+///     )
+///     .build();
+///
+/// assert_eq!(response.links[0].rel.as_ref(), "author");
+/// ```
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LinkBuilder {
+    link: Link,
+}
+
+impl LinkBuilder {
+    /// Creates a link builder with the given relation type.
+    ///
+    /// The relation is validated immediately. This catches invalid builder input before the
+    /// response is serialized.
+    pub fn new<R: AsRef<str>>(rel: R) -> Self {
+        Self {
+            link: Link::new(Rel::new(rel)),
+        }
+    }
+
+    /// Sets the media type of the link.
+    ///
+    /// This writes the optional `type` member from [RFC 7033 section 4.4.4.2].
+    ///
+    /// [RFC 7033 section 4.4.4.2]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.2
+    pub fn r#type<S: Into<String>>(mut self, r#type: S) -> Self {
+        self.link.r#type = Some(r#type.into());
+        self
+    }
+
+    /// Sets the target URI of the link.
+    ///
+    /// The value is validated as a [`JrdUri`] and serialized as the optional `href` member from
+    /// [RFC 7033 section 4.4.4.3].
+    ///
+    /// [RFC 7033 section 4.4.4.3]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.3
+    pub fn href<S: AsRef<str>>(mut self, href: S) -> Self {
+        self.link.href = Some(JrdUri::new(href));
+        self
+    }
+
+    /// Adds a single localized title to the link.
+    ///
+    /// RFC 7033 serializes titles as an object keyed by language tag, so repeated calls insert or
+    /// replace entries in that object.
+    ///
+    /// [RFC 7033 section 4.4.4.4]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.4
+    pub fn title<L: Into<String>, V: Into<String>>(mut self, language: L, value: V) -> Self {
+        let title = Title::new(language, value);
+        self.link
+            .titles
+            .get_or_insert_with(BTreeMap::new)
+            .insert(title.language, title.value);
+        self
+    }
+
+    /// Sets the complete language-keyed title object for the link.
+    ///
+    /// The argument can be any owned iterator of `(language, title)` pairs, including a moved
+    /// `BTreeMap` or `HashMap`. Keys and values are converted into owned strings and stored as the
+    /// JSON object described by [RFC 7033 section 4.4.4.4].
+    ///
+    /// [RFC 7033 section 4.4.4.4]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.4
+    pub fn titles<I, L, V>(mut self, titles: I) -> Self
+    where
+        I: IntoIterator<Item = (L, V)>,
+        L: Into<String>,
+        V: Into<String>,
+    {
+        let titles = titles
+            .into_iter()
+            .map(|(language, value)| (language.into(), value.into()))
+            .collect();
+        self.link.titles = Some(titles);
+        self
+    }
+
+    /// Adds a string-valued property to the link.
+    ///
+    /// The property identifier is validated as a [`JrdUri`]. The value serializes as a JSON string
+    /// under that property key.
+    ///
+    /// [RFC 7033 section 4.4.4.5]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.5
+    pub fn property<K: AsRef<str>, V: Into<String>>(mut self, key: K, value: V) -> Self {
+        self.link
+            .properties
+            .get_or_insert_with(BTreeMap::new)
+            .insert(JrdUri::new(key), Some(value.into()));
+        self
+    }
+
+    /// Adds a null-valued property to the link.
+    ///
+    /// This writes the property with a JSON `null` value. It is different from leaving the
+    /// property out of the map.
+    ///
+    /// [RFC 7033 section 4.4.4.5]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.5
+    pub fn null_property<K: AsRef<str>>(mut self, key: K) -> Self {
+        self.link
+            .properties
+            .get_or_insert_with(BTreeMap::new)
+            .insert(JrdUri::new(key), None);
+        self
+    }
+
+    /// Sets the complete property object for the link.
+    ///
+    /// The argument can be any owned iterator of `(JrdUri, Option<String>)` pairs. Use `Some` for
+    /// string-valued properties and `None` for JSON `null` values.
+    ///
+    /// [RFC 7033 section 4.4.4.5]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.5
+    pub fn properties<I>(mut self, properties: I) -> Self
+    where
+        I: IntoIterator<Item = (JrdUri, Option<String>)>,
+    {
+        self.link.properties = Some(properties.into_iter().collect());
+        self
+    }
+
+    /// Builds the link.
+    ///
+    /// This can be omitted if the link is being converted to a `Link` directly from the builder as
+    /// `LinkBuilder` also implements `From<LinkBuilder> for Link`.
+    pub fn build(self) -> Link {
+        self.link
+    }
+}
+
+impl From<LinkBuilder> for Link {
+    fn from(builder: LinkBuilder) -> Self {
+        builder.build()
+    }
+}
+
+/// Custom debug implementation to avoid printing `None` fields
+impl Debug for LinkBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("LinkBuilder").field(&self.link).finish()
+    }
+}
+
+/// Custom debug implementation to avoid printing `None` fields
+impl Debug for Link {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut debug = f.debug_struct("Link");
+        let mut debug = debug.field("rel", &self.rel);
+        if let Some(r#type) = &self.r#type {
+            debug = debug.field("type", &r#type);
+        }
+        if let Some(href) = &self.href {
+            debug = debug.field("href", &href);
+        }
+        if let Some(titles) = &self.titles {
+            debug = debug.field("titles", &titles);
+        }
+        if let Some(properties) = &self.properties {
+            debug = debug.field("properties", &properties);
+        }
+        debug.finish()
+    }
+}
+
+/// A title in the WebFinger response.
+///
+/// RFC 7033 serializes titles as a JSON object, not as a list of title objects. `Title` is a small
+/// helper for builder-style construction where a caller wants to name one `(language, value)` pair
+/// before it is inserted into the link's language-keyed map.
+///
+/// The language is stored as `String` because RFC 7033 points at language tags but does not require
+/// WebFinger implementations to enforce a particular registry or normalization policy here.
+///
+/// See [RFC 7033 section 4.4.4.4].
+///
+/// # Examples
+///
+/// ```rust
+/// use webfinger_rs::{Link, Title};
+///
+/// let title = Title::new("en-us", "Carol's Profile");
+/// let link = Link::builder("http://webfinger.net/rel/profile-page")
+///     .title(title.language, title.value)
+///     .build();
+///
+/// assert_eq!(
+///     link.titles.unwrap().get("en-us").map(String::as_str),
+///     Some("Carol's Profile"),
+/// );
+/// ```
+///
+/// [RFC 7033 section 4.4.4.4]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.4
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Title {
+    /// The language of the title.
+    ///
+    /// This can be any valid language tag as defined in [RFC
+    /// 5646](https://www.rfc-editor.org/rfc/rfc5646.html) or the string `und` to indicate an
+    /// undefined language.
+    pub language: String,
+    /// The title text for this language.
+    pub value: String,
+}
+
+impl Title {
+    /// Creates a title pair with the given language and value.
+    pub fn new<L: Into<String>, V: Into<String>>(language: L, value: V) -> Self {
+        Self {
+            language: language.into(),
+            value: value.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::Debug;
+    use std::hash::Hash;
+
+    use serde::{Deserialize, Serialize};
+    use serde_json::json;
+
+    use super::*;
+
+    type Result<T = (), E = Box<dyn std::error::Error>> = std::result::Result<T, E>;
+
+    fn assert_data_traits<T>()
+    where
+        T: Clone + Debug + Eq + Ord + Hash + Send + Sync + Serialize + for<'de> Deserialize<'de>,
+    {
+    }
+
+    fn assert_ordered_value_traits<T>()
+    where
+        T: Clone + Debug + Eq + Ord + Hash + Send + Sync + Serialize + for<'de> Deserialize<'de>,
+    {
+    }
+
+    fn assert_builder_traits<T>()
+    where
+        T: Clone + Debug + Eq + Ord + Hash + Send + Sync,
+    {
+    }
+
+    #[test]
+    fn implements_applicable_common_traits() {
+        assert_data_traits::<Link>();
+        assert_ordered_value_traits::<Title>();
+        assert_builder_traits::<LinkBuilder>();
+    }
+
+    #[test]
+    fn builder_serializes_titles_as_language_object() -> Result {
+        let link = Link::builder("http://webfinger.net/rel/profile-page")
+            .href("https://example.com/profile/carol")
+            .title("en-us", "Carol's Profile")
+            .build();
+
+        let json = serde_json::to_value(link)?;
+
+        assert_eq!(
+            json,
+            json!({
+                "rel": "http://webfinger.net/rel/profile-page",
+                "href": "https://example.com/profile/carol",
+                "titles": {
+                    "en-us": "Carol's Profile"
+                }
+            })
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn builder_serializes_null_properties() -> Result {
+        let link = Link::builder("author")
+            .property("https://example.com/ns/role", "editor")
+            .null_property("https://example.com/ns/old-role")
+            .build();
+
+        let json = serde_json::to_value(link)?;
+
+        assert_eq!(
+            json,
+            json!({
+                "rel": "author",
+                "properties": {
+                    "https://example.com/ns/role": "editor",
+                    "https://example.com/ns/old-role": null
+                }
+            })
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn deserialization_rejects_title_array_shape() {
+        let json = r#"
+        {
+          "rel": "author",
+          "titles": [
+            {
+              "language": "en-us",
+              "value": "Carol"
+            }
+          ]
+        }
+        "#;
+
+        let error = serde_json::from_str::<Link>(json).expect_err("title array");
+
+        assert!(error.to_string().contains("invalid type"));
+    }
+
+    #[test]
+    fn deserialization_rejects_relative_property_identifiers() {
+        let json = r#"
+        {
+          "rel": "author",
+          "properties": {
+            "/ns/role": "editor"
+          }
+        }
+        "#;
+
+        let error = serde_json::from_str::<Link>(json).expect_err("relative property identifier");
+
+        assert!(error.to_string().contains("invalid JRD URI"));
+    }
+}

--- a/webfinger-rs/src/types/rel.rs
+++ b/webfinger-rs/src/types/rel.rs
@@ -6,6 +6,7 @@ use serde::de::{self, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::Error;
+use crate::types::jrd_uri::is_absolute_uri;
 
 /// Link relation type.
 ///
@@ -160,13 +161,6 @@ impl Visitor<'_> for RelVisitor {
     {
         Rel::try_new(value).map_err(E::custom)
     }
-}
-
-fn is_absolute_uri(value: &str) -> bool {
-    let Ok(uri) = value.parse::<http::Uri>() else {
-        return false;
-    };
-    uri.scheme().is_some()
 }
 
 fn is_registered_relation_type(value: &str) -> bool {

--- a/webfinger-rs/src/types/request.rs
+++ b/webfinger-rs/src/types/request.rs
@@ -86,7 +86,7 @@ use crate::{Error, Rel, Resource};
 ///
 /// async fn handler(request: WebFingerRequest) -> WebFingerResponse {
 ///     // ... handle the request ...
-/// # WebFingerResponse::new("")
+/// # WebFingerResponse::new("acct:carol@example.com")
 /// }
 /// ```
 #[serde_as]

--- a/webfinger-rs/src/types/response.rs
+++ b/webfinger-rs/src/types/response.rs
@@ -1,20 +1,34 @@
-use std::collections::HashMap;
-use std::fmt;
+use std::collections::BTreeMap;
+use std::fmt::{self, Debug};
 
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
-use crate::Rel;
+use crate::Error;
+use crate::{JrdUri, Link};
 
 /// A WebFinger response.
 ///
-/// This represents the response portion of a WebFinger query that is returned by a WebFinger
-/// server.
+/// This is the JSON Resource Descriptor (JRD) returned by a WebFinger server. The Rust fields map
+/// directly to the top-level members from RFC 7033:
 ///
-/// See [RFC 7033 Section 4.4](https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4) for more
-/// information.
+/// - [`subject`](Self::subject) is required and uses [`JrdUri`] because the RFC defines it as the
+///   URI of the resource described by the JRD.
+/// - [`aliases`](Self::aliases) is an optional list of URI strings, also represented as
+///   [`JrdUri`].
+/// - [`properties`](Self::properties) is an optional object with URI property identifiers and
+///   string-or-null values.
+/// - [`links`](Self::links) is the JRD link array. Missing `links` deserializes as an empty
+///   vector.
+///
+/// The response serializes to the RFC JSON shape. It uses typed wrappers for URI-valued and
+/// relation-valued fields while keeping builder methods string-friendly for application code.
+///
+/// See [RFC 7033 section 4.4].
 ///
 /// # Examples
+///
+/// Constructing a response with builders keeps common server code concise:
 ///
 /// ```rust
 /// use webfinger_rs::{Link, WebFingerResponse};
@@ -31,6 +45,29 @@ use crate::Rel;
 ///     .link(avatar)
 ///     .link(profile)
 ///     .build();
+/// ```
+///
+/// JSON `null` property values are represented with `null_property` on the builder:
+///
+/// ```rust
+/// use webfinger_rs::{Link, WebFingerResponse};
+///
+/// let response = WebFingerResponse::builder("acct:carol@example.com")
+///     .property("https://example.com/ns/role", "developer")
+///     .null_property("https://example.com/ns/previous-role")
+///     .link(
+///         Link::builder("author")
+///             .href("https://example.com/people/carol")
+///             .null_property("https://example.com/ns/legacy-page"),
+///     )
+///     .build();
+///
+/// let json = serde_json::to_value(response)?;
+/// assert_eq!(
+///     json["properties"]["https://example.com/ns/previous-role"],
+///     serde_json::Value::Null,
+/// );
+/// # Ok::<(), serde_json::Error>(())
 /// ```
 ///
 /// `Response` can be used as a response in Axum handlers as it implements
@@ -52,48 +89,81 @@ use crate::Rel;
 ///         .build()
 /// }
 /// ```
+///
+/// [RFC 7033 section 4.4]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4
 #[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Response {
     /// The subject of the response.
     ///
-    /// This is the URI of the resource that the response is about.
+    /// This is the URI of the resource that the JRD describes. RFC 7033 makes it required when a
+    /// response is returned, so the Rust field is not optional.
     ///
-    /// Defined in [RFC 7033 Section
-    /// 4.4.1](https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.1)
-    pub subject: String,
+    /// [`JrdUri`] is used instead of `String` so relative references are rejected during
+    /// deserialization and builder construction.
+    ///
+    /// See [RFC 7033 section 4.4.1].
+    ///
+    /// [RFC 7033 section 4.4.1]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.1
+    pub subject: JrdUri,
 
     /// The aliases of the response.
     ///
-    /// Defined in [RFC 7033 Section
-    /// 4.4.2](https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.2)
-    pub aliases: Option<Vec<String>>,
+    /// Aliases are additional URI strings for the same subject. The field is optional because the
+    /// JSON member may be absent. Each value is a [`JrdUri`] for the same reason as
+    /// [`Response::subject`].
+    ///
+    /// See [RFC 7033 section 4.4.2].
+    ///
+    /// [RFC 7033 section 4.4.2]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.2
+    pub aliases: Option<Vec<JrdUri>>,
 
     /// The properties of the response.
     ///
-    /// Defined in [RFC 7033 Section
-    /// 4.4.3](https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.3)
-    pub properties: Option<HashMap<String, String>>,
+    /// JRD properties are a JSON object whose names are URI strings. Values may be strings or JSON
+    /// `null`, so the Rust value type is `Option<String>`. `None` serializes as a property value of
+    /// `null`; it does not omit the property from the map.
+    ///
+    /// A `BTreeMap` is used for deterministic ordering and to support the standard ordering and
+    /// hashing traits on `Response`.
+    ///
+    /// See [RFC 7033 section 4.4.3].
+    ///
+    /// [RFC 7033 section 4.4.3]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.3
+    pub properties: Option<BTreeMap<JrdUri, Option<String>>>,
 
     /// The links of the response.
     ///
-    /// Defined in [RFC 7033 Section
-    /// 4.4.4](https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4)
+    /// This is the JRD `links` array. A missing JSON member deserializes to an empty vector so code
+    /// can iterate links without handling a separate absent state.
+    ///
+    /// See [RFC 7033 section 4.4.4] and [`Link`].
+    ///
+    /// [RFC 7033 section 4.4.4]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4
+    #[serde(default)]
     pub links: Vec<Link>,
 }
 
 impl Response {
-    /// Create a new response with the given subject.
-    pub fn new<S: Into<String>>(subject: S) -> Self {
+    /// Creates a response with the given subject and no optional JRD members.
+    ///
+    /// This constructor is intended for application-controlled subject strings. It validates the
+    /// subject as a [`JrdUri`] and panics if the string is not an absolute URI. Use
+    /// [`Response::try_builder`] when the subject comes from external input.
+    pub fn new<S: AsRef<str>>(subject: S) -> Self {
         Self {
-            subject: subject.into(),
+            subject: JrdUri::new(subject),
             aliases: None,
             properties: None,
             links: Vec::new(),
         }
     }
 
-    /// Create a new [`Builder`] with the given subject.
+    /// Creates a [`Builder`] with the given subject.
+    ///
+    /// The builder accepts strings at the API boundary and stores typed JRD values internally. This
+    /// keeps straightforward server responses concise while still producing the RFC-shaped JSON
+    /// object.
     ///
     /// # Examples
     ///
@@ -108,8 +178,25 @@ impl Response {
     ///     .link(avatar)
     ///     .build();
     /// ```
-    pub fn builder<S: Into<String>>(subject: S) -> Builder {
-        Builder::new(subject.into())
+    pub fn builder<S: AsRef<str>>(subject: S) -> Builder {
+        Builder::new(subject)
+    }
+
+    /// Tries to create a new [`Builder`] with the given subject.
+    ///
+    /// Use this when the subject string has not already been validated by application logic. The
+    /// returned builder has the same methods as [`Response::builder`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use webfinger_rs::WebFingerResponse;
+    ///
+    /// assert!(WebFingerResponse::try_builder("acct:carol@example.com").is_ok());
+    /// assert!(WebFingerResponse::try_builder("/users/carol").is_err());
+    /// ```
+    pub fn try_builder<S: AsRef<str>>(subject: S) -> Result<Builder, Error> {
+        Ok(Builder::new(JrdUri::try_new(subject)?))
     }
 }
 
@@ -121,244 +208,314 @@ impl fmt::Display for Response {
 
 /// A builder for a WebFinger response.
 ///
-/// This is used to construct a [`Response`] with the desired fields.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// `Builder` constructs a [`Response`] using the JRD member names from RFC 7033. It is the
+/// preferred API for ordinary server responses because it accepts string-like values and converts
+/// them to [`JrdUri`] or [`Link`] where the stored response type is stricter than JSON text.
+///
+/// # Examples
+///
+/// ```rust
+/// use webfinger_rs::{Link, WebFingerResponse};
+///
+/// let response = WebFingerResponse::builder("acct:carol@example.com")
+///     .alias("https://example.com/users/carol")
+///     .property("https://example.com/ns/display-name", "Carol")
+///     .link(Link::builder("avatar").href("https://example.com/avatar/carol.png"))
+///     .build();
+///
+/// assert_eq!(response.subject.as_ref(), "acct:carol@example.com");
+/// ```
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Builder {
     response: Response,
 }
 
 impl Builder {
-    /// Create a new response builder with the given subject.
-    pub fn new<S: Into<String>>(subject: S) -> Self {
+    /// Creates a response builder with the given subject.
+    ///
+    /// The subject is validated immediately as a [`JrdUri`].
+    pub fn new<S: AsRef<str>>(subject: S) -> Self {
         Self {
-            response: Response::new(subject.into()),
+            response: Response::new(subject),
         }
     }
 
-    /// Add an alias to the response.
+    /// Adds an alias URI to the response.
     ///
-    /// Defined in [RFC 7033 Section
-    /// 4.4.2](https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.2)
-    pub fn alias<S: Into<String>>(mut self, alias: S) -> Self {
+    /// The value is validated as a [`JrdUri`] and serialized in the `aliases` array from
+    /// [RFC 7033 section 4.4.2].
+    ///
+    /// [RFC 7033 section 4.4.2]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.2
+    pub fn alias<S: AsRef<str>>(mut self, alias: S) -> Self {
         self.response
             .aliases
             .get_or_insert_with(Vec::new)
-            .push(alias.into());
+            .push(JrdUri::new(alias));
         self
     }
 
-    /// Add a property to the response.
+    /// Adds a string-valued property to the response.
     ///
-    /// Defined in [RFC 7033 Section
-    /// 4.4.3](https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.3)
-    pub fn property<K: Into<String>, V: Into<String>>(mut self, key: K, value: V) -> Self {
+    /// The key is validated as a [`JrdUri`]. The value serializes as a JSON string under that
+    /// property identifier.
+    ///
+    /// [RFC 7033 section 4.4.3]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.3
+    pub fn property<K: AsRef<str>, V: Into<String>>(mut self, key: K, value: V) -> Self {
         self.response
             .properties
-            .get_or_insert_with(HashMap::new)
-            .insert(key.into(), value.into());
+            .get_or_insert_with(BTreeMap::new)
+            .insert(JrdUri::new(key), Some(value.into()));
         self
     }
 
-    /// Add a link to the response.
+    /// Adds a null-valued property to the response.
+    ///
+    /// This writes the property with a JSON `null` value. It is different from leaving the
+    /// property out of the JRD object.
+    ///
+    /// [RFC 7033 section 4.4.3]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.3
+    pub fn null_property<K: AsRef<str>>(mut self, key: K) -> Self {
+        self.response
+            .properties
+            .get_or_insert_with(BTreeMap::new)
+            .insert(JrdUri::new(key), None);
+        self
+    }
+
+    /// Adds a link to the response.
     ///
     /// If the link is constructed with a builder, it is not necessary to call the `build` method on
     /// the link as the builder implements `From<LinkBuilder> for Link`.
     ///
-    /// Defined in [RFC 7033 Section
-    /// 4.4.4](https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4)
+    /// This appends to the `links` array from [RFC 7033 section 4.4.4].
+    ///
+    /// [RFC 7033 section 4.4.4]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4
     pub fn link<L: Into<Link>>(mut self, link: L) -> Self {
         self.response.links.push(link.into());
         self
     }
 
-    /// Set the links of the response.
+    /// Sets the complete link array for the response.
     ///
-    /// Defined in [RFC 7033 Section
-    /// 4.4.4](https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4)
+    /// Use this when links are already collected. Use [`Builder::link`] when appending links one at
+    /// a time.
+    ///
+    /// [RFC 7033 section 4.4.4]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4
     pub fn links(mut self, links: Vec<Link>) -> Self {
         self.response.links = links;
         self
     }
 
-    /// Build the response.
+    /// Builds the response.
     pub fn build(self) -> Response {
         self.response
     }
 }
 
-/// A link in the WebFinger response.
-///
-/// Defined in [RFC 7033 Section 4.4](https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4)
-#[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-pub struct Link {
-    /// The relation type of the link.
-    ///
-    /// Defined in [RFC 7033 Section
-    /// 4.4.4.1](https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.1)
-    pub rel: Rel,
-
-    /// The media type of the link.
-    ///
-    /// Defined in [RFC 7033 Section
-    /// 4.4.4.2](https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.2)
-    pub r#type: Option<String>,
-
-    /// The target URI of the link.
-    ///
-    /// Defined in [RFC 7033 Section
-    /// 4.4.4.3](https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.3)
-    pub href: Option<String>,
-
-    /// The titles of the link.
-    ///
-    /// Defined in [RFC 7033 Section
-    /// 4.4.4.4](https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.4)
-    pub titles: Option<Vec<Title>>,
-
-    /// The properties of the link.
-    ///
-    /// Defined in [RFC 7033 Section
-    /// 4.4.4.5](https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.5)
-    pub properties: Option<HashMap<String, Option<String>>>,
+/// Custom debug implementation to avoid printing `None` fields
+impl Debug for Builder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Builder").field(&self.response).finish()
+    }
 }
 
-impl Link {
-    /// Create a new link with the given relation type.
-    pub fn new(rel: Rel) -> Self {
-        Self {
-            rel,
-            r#type: None,
-            href: None,
-            titles: None,
-            properties: None,
+/// Custom debug implementation to avoid printing `None` fields
+impl Debug for Response {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut debug = f.debug_struct("Response");
+        let mut debug = debug.field("subject", &self.subject);
+        if let Some(aliases) = &self.aliases {
+            debug = debug.field("aliases", &aliases);
         }
-    }
-
-    /// Create a new [`LinkBuilder`] with the given relation type.
-    pub fn builder<R: AsRef<str>>(rel: R) -> LinkBuilder {
-        LinkBuilder::new(rel)
-    }
-}
-
-/// A builder for a WebFinger link.
-///
-/// This is used to construct a [`Link`] with the desired fields.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LinkBuilder {
-    link: Link,
-}
-
-impl LinkBuilder {
-    /// Create a new link builder with the given relation type.
-    pub fn new<R: AsRef<str>>(rel: R) -> Self {
-        Self {
-            link: Link::new(Rel::new(rel)),
+        if let Some(properties) = &self.properties {
+            debug = debug.field("properties", &properties);
         }
-    }
-
-    /// Set the media type of the link.
-    ///
-    /// Defined in [RFC 7033 Section
-    /// 4.4.4.2](https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.2)
-    pub fn r#type<S: Into<String>>(mut self, r#type: S) -> Self {
-        self.link.r#type = Some(r#type.into());
-        self
-    }
-
-    /// Set the target URI of the link.
-    ///
-    /// Defined in [RFC 7033 Section
-    /// 4.4.4.3](https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.3)
-    pub fn href<S: Into<String>>(mut self, href: S) -> Self {
-        self.link.href = Some(href.into());
-        self
-    }
-
-    /// Add a single title for the the link.
-    ///
-    /// Defined in [RFC 7033 Section
-    /// 4.4.4.4](https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.4)
-    pub fn title<L: Into<String>, V: Into<String>>(mut self, language: L, value: V) -> Self {
-        let title = Title::new(language, value);
-        self.link.titles.get_or_insert_with(Vec::new).push(title);
-        self
-    }
-
-    /// Set the titles of the link.
-    ///
-    /// Defined in [RFC 7033 Section
-    /// 4.4.4.4](https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.4)
-    pub fn titles(mut self, titles: Vec<Title>) -> Self {
-        self.link.titles = Some(titles);
-        self
-    }
-
-    /// Add a single property to the link.
-    ///
-    /// Defined in [RFC 7033 Section
-    /// 4.4.4.5](https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.5)
-    pub fn property<K: Into<String>, V: Into<Option<String>>>(mut self, key: K, value: V) -> Self {
-        self.link
-            .properties
-            .get_or_insert_with(HashMap::new)
-            .insert(key.into(), value.into());
-        self
-    }
-
-    /// Set the properties of the link.
-    ///
-    /// Defined in [RFC 7033 Section
-    /// 4.4.4.5](https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.5)
-    pub fn properties(mut self, properties: HashMap<String, Option<String>>) -> Self {
-        self.link.properties = Some(properties);
-        self
-    }
-
-    /// Build the link.
-    ///
-    /// This can be omitted if the link is being converted to a `Link` directly from the builder as
-    /// `LinkBuilder` also implements `From<LinkBuilder> for Link`.
-    pub fn build(self) -> Link {
-        self.link
+        debug.field("links", &self.links).finish()
     }
 }
 
-impl From<LinkBuilder> for Link {
-    fn from(builder: LinkBuilder) -> Self {
-        builder.build()
+#[cfg(test)]
+mod tests {
+    use std::fmt::{Debug, Display};
+    use std::hash::Hash;
+
+    use serde::{Deserialize, Serialize};
+    use serde_json::json;
+
+    use super::*;
+    use crate::Rel;
+
+    type Result<T = (), E = Box<dyn std::error::Error>> = std::result::Result<T, E>;
+
+    fn assert_data_traits<T>()
+    where
+        T: Clone
+            + Debug
+            + Display
+            + Eq
+            + Ord
+            + Hash
+            + Send
+            + Sync
+            + Serialize
+            + for<'de> Deserialize<'de>,
+    {
     }
-}
 
-/// A title in the WebFinger response.
-///
-/// Defined in [RFC 7033 Section 4.4.4.4](https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.4)
-///
-/// # Examples
-///
-/// ```rust
-/// use webfinger_rs::Title;
-///
-/// let title = Title::new("en-us", "Carol's Profile");
-/// ```
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Title {
-    /// The language of the title.
-    ///
-    /// This can be any valid language tag as defined in [RFC
-    /// 5646](https://www.rfc-editor.org/rfc/rfc5646.html) or the string `und` to indicate an
-    /// undefined language.
-    pub language: String,
-    /// The value of the title.
-    pub value: String,
-}
+    fn assert_builder_traits<T>()
+    where
+        T: Clone + Debug + Eq + Ord + Hash + Send + Sync,
+    {
+    }
 
-impl Title {
-    /// Create a new title with the given language and value.
-    pub fn new<L: Into<String>, V: Into<String>>(language: L, value: V) -> Self {
-        Self {
-            language: language.into(),
-            value: value.into(),
+    #[test]
+    fn implements_applicable_common_traits() {
+        assert_data_traits::<Response>();
+        assert_builder_traits::<Builder>();
+    }
+
+    #[test]
+    fn deserializes_rfc_shaped_jrd_with_null_properties_and_title_object() -> Result {
+        let json = r#"
+        {
+          "subject": "http://blog.example.com/article/id/314",
+          "aliases": [
+            "http://blog.example.com/cool_new_thing",
+            "http://blog.example.com/steve/article/7"
+          ],
+          "properties": {
+            "http://blgx.example.net/ns/version": "1.3",
+            "http://blgx.example.net/ns/ext": null
+          },
+          "links": [
+            {
+              "rel": "author",
+              "href": "http://blog.example.com/author/steve",
+              "titles": {
+                "en-us": "The Magical World of Steve",
+                "fr": "Le Monde Magique de Steve"
+              },
+              "properties": {
+                "http://example.com/role": "editor",
+                "http://example.com/old-role": null
+              }
+            }
+          ]
         }
+        "#;
+
+        let response = serde_json::from_str::<Response>(json)?;
+        let properties = response.properties.as_ref().expect("properties");
+        let links = &response.links;
+        let link = links.first().expect("link");
+        let titles = link.titles.as_ref().expect("titles");
+        let link_properties = link.properties.as_ref().expect("link properties");
+
+        assert_eq!(
+            response.subject.as_ref(),
+            "http://blog.example.com/article/id/314"
+        );
+        assert_eq!(
+            response.aliases.as_ref().expect("aliases")[0].as_ref(),
+            "http://blog.example.com/cool_new_thing"
+        );
+        assert_eq!(
+            properties
+                .get(&JrdUri::new("http://blgx.example.net/ns/version"))
+                .expect("version")
+                .as_deref(),
+            Some("1.3")
+        );
+        assert_eq!(
+            properties.get(&JrdUri::new("http://blgx.example.net/ns/ext")),
+            Some(&None)
+        );
+        assert_eq!(link.rel, Rel::new("author"));
+        assert_eq!(
+            link.href.as_ref().expect("href").as_ref(),
+            "http://blog.example.com/author/steve"
+        );
+        assert_eq!(
+            titles.get("en-us").map(String::as_str),
+            Some("The Magical World of Steve")
+        );
+        assert_eq!(
+            link_properties.get(&JrdUri::new("http://example.com/old-role")),
+            Some(&None)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn serializes_builder_output_as_rfc_shaped_jrd() -> Result {
+        let response = Response::builder("acct:carol@example.com")
+            .alias("https://example.com/profile/carol")
+            .property("https://example.com/ns/role", "developer")
+            .null_property("https://example.com/ns/old-role")
+            .link(
+                Link::builder("http://webfinger.net/rel/profile-page")
+                    .href("https://example.com/profile/carol")
+                    .title("en-us", "Carol's Profile")
+                    .property("https://example.com/ns/verified", "true")
+                    .null_property("https://example.com/ns/legacy"),
+            )
+            .build();
+
+        let json = serde_json::to_value(response)?;
+
+        assert_eq!(
+            json,
+            json!({
+                "subject": "acct:carol@example.com",
+                "aliases": ["https://example.com/profile/carol"],
+                "properties": {
+                    "https://example.com/ns/role": "developer",
+                    "https://example.com/ns/old-role": null
+                },
+                "links": [
+                    {
+                        "rel": "http://webfinger.net/rel/profile-page",
+                        "href": "https://example.com/profile/carol",
+                        "titles": {
+                            "en-us": "Carol's Profile"
+                        },
+                        "properties": {
+                            "https://example.com/ns/verified": "true",
+                            "https://example.com/ns/legacy": null
+                        }
+                    }
+                ]
+            })
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_relative_jrd_uris() {
+        let json =
+            r#"{"subject":"acct:carol@example.com","links":[{"rel":"author","href":"/carol"}]}"#;
+
+        let error = serde_json::from_str::<Response>(json).expect_err("relative href");
+
+        assert!(error.to_string().contains("invalid JRD URI"));
+    }
+
+    #[test]
+    fn rejects_empty_relation_types() {
+        let json = r#"{"subject":"acct:carol@example.com","links":[{"rel":""}]}"#;
+
+        let error = serde_json::from_str::<Response>(json).expect_err("empty rel");
+
+        assert!(error.to_string().contains("invalid relation type"));
+    }
+
+    #[test]
+    fn deserializes_jrd_without_links() -> Result {
+        let json = r#"{"subject":"acct:carol@example.com"}"#;
+
+        let response = serde_json::from_str::<Response>(json)?;
+
+        assert!(response.links.is_empty());
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- add `JrdUri` for URI-valued JRD fields and property identifiers
- move link response modeling into its own module with RFC-shaped titles and nullable properties
- align response builders, Rustdoc, and serialization tests with RFC 7033 JRD semantics

## Validation

- `cargo fmt --all --check`
- `cargo test --workspace`
- `cargo test --locked --all-features --doc`
- `cargo clippy --workspace --all-features --all-targets`
