### PR TITLE
fix: tighten WebFinger URI validation

### DIFF
--- a/webfinger-cli/src/main.rs
+++ b/webfinger-cli/src/main.rs
@@ -153,4 +153,16 @@ mod tests {
 
         assert_eq!(host, "example.org");
     }
+
+    /// Rejects non-hierarchical HTTP resource text before host inference.
+    #[test]
+    fn resource_rejects_http_uri_without_authority() {
+        let command = command("http:foo");
+
+        let error = command
+            .resource()
+            .expect_err("HTTP resource without authority");
+
+        assert!(error.to_string().contains("invalid resource"));
+    }
 }

--- a/webfinger-rs/src/types/jrd_uri.rs
+++ b/webfinger-rs/src/types/jrd_uri.rs
@@ -19,7 +19,8 @@ use crate::Error;
 ///
 /// See [RFC 7033 section 4.4.1] for `subject`, [section 4.4.2] for `aliases`,
 /// [section 4.4.3] for response properties, [section 4.4.4.3] for link `href`, and
-/// [section 4.4.4.5] for link properties.
+/// [section 4.4.4.5] for link properties. Those sections rely on URI syntax from RFC 3986,
+/// including [section 2.1] percent escapes and [section 4.3] absolute URIs.
 ///
 /// # Examples
 ///
@@ -47,6 +48,8 @@ use crate::Error;
 /// [section 4.4.3]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.3
 /// [section 4.4.4.3]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.3
 /// [section 4.4.4.5]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.5
+/// [section 2.1]: https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1
+/// [section 4.3]: https://www.rfc-editor.org/rfc/rfc3986.html#section-4.3
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct JrdUri(String);
 
@@ -169,11 +172,60 @@ impl Visitor<'_> for JrdUriVisitor {
     }
 }
 
+/// Returns whether `value` is an absolute URI string under the crate's JRD URI policy.
+///
+/// RFC 7033's JRD members call these values URI strings, not arbitrary text. This helper enforces
+/// the pieces the crate relies on before storing a [`JrdUri`] or accepting a URI-valued [`Rel`]:
+/// a valid RFC 3986 scheme, syntactically valid percent escapes, and successful parsing by
+/// [`http::Uri`]. The explicit percent-escape check is necessary because `http::Uri` accepts
+/// malformed escapes such as `%GG`, while RFC 3986 section 2.1 constrains percent encoding to `%`
+/// followed by two hexadecimal digits.
+///
+/// [`Rel`]: crate::Rel
+///
+/// See [RFC 3986 section 2.1] for percent encoding, [section 3.1] for scheme syntax, and
+/// [section 4.3] for absolute URI syntax.
+///
+/// [RFC 3986 section 2.1]: https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1
+/// [section 3.1]: https://www.rfc-editor.org/rfc/rfc3986.html#section-3.1
+/// [section 4.3]: https://www.rfc-editor.org/rfc/rfc3986.html#section-4.3
 pub(crate) fn is_absolute_uri(value: &str) -> bool {
     let Some((scheme, _rest)) = value.split_once(':') else {
         return false;
     };
-    is_uri_scheme(scheme) && value.parse::<http::Uri>().is_ok()
+    let has_scheme = is_uri_scheme(scheme);
+    let has_valid_percent_encoding = has_valid_percent_escapes(value);
+    let parses_as_uri = value.parse::<http::Uri>().is_ok();
+
+    has_scheme && has_valid_percent_encoding && parses_as_uri
+}
+
+/// Returns whether every `%` starts a complete RFC 3986 percent escape.
+///
+/// RFC 3986 section 2.1 defines `pct-encoded` as `%` followed by exactly two hexadecimal digits.
+/// Some URI parsers preserve malformed escapes as ordinary path text, so URI-valued WebFinger
+/// fields need this check before accepting user or JSON input as validated URI text.
+///
+/// See [RFC 3986 section 2.1].
+///
+/// [RFC 3986 section 2.1]: https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1
+fn has_valid_percent_escapes(value: &str) -> bool {
+    let mut bytes = value.as_bytes().iter();
+    while let Some(byte) = bytes.next() {
+        if *byte != b'%' {
+            continue;
+        }
+        let Some(high) = bytes.next() else {
+            return false;
+        };
+        let Some(low) = bytes.next() else {
+            return false;
+        };
+        if !high.is_ascii_hexdigit() || !low.is_ascii_hexdigit() {
+            return false;
+        }
+    }
+    true
 }
 
 fn is_uri_scheme(scheme: &str) -> bool {
@@ -264,6 +316,18 @@ mod tests {
         let error = JrdUri::try_new("carol@example.com").expect_err("non-URI string");
 
         assert!(error.to_string().contains("invalid JRD URI"));
+    }
+
+    #[test]
+    fn rejects_malformed_percent_escapes() {
+        for uri in ["https://example.org/a%GG", "acct:carol%GG@example.com"] {
+            let error = JrdUri::try_new(uri).expect_err("malformed percent escape");
+
+            assert!(
+                error.to_string().contains("invalid JRD URI"),
+                "expected invalid JRD URI error for {uri:?}, got {error:?}",
+            );
+        }
     }
 
     #[test]

--- a/webfinger-rs/src/types/rel.rs
+++ b/webfinger-rs/src/types/rel.rs
@@ -20,7 +20,8 @@ use crate::types::jrd_uri::is_absolute_uri;
 /// so deserialized and programmatically built links use the same representation.
 ///
 /// Registered relation type names use the `reg-rel-type` syntax from [RFC 5988 section 5.3].
-/// URI-valued relation types are validated as absolute URI strings.
+/// URI-valued relation types are validated as absolute URI strings under RFC 3986, including the
+/// [section 2.1] percent-encoding rule.
 ///
 /// See [RFC 7033 section 4.4.4.1].
 ///
@@ -48,6 +49,7 @@ use crate::types::jrd_uri::is_absolute_uri;
 ///
 /// [RFC 7033 section 4.4.4.1]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.1
 /// [RFC 5988 section 5.3]: https://www.rfc-editor.org/rfc/rfc5988.html#section-5.3
+/// [section 2.1]: https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Rel(String);
 
@@ -263,6 +265,13 @@ mod tests {
     #[test]
     fn rejects_relative_uri_relation_types() {
         let error = Rel::try_new("/rel/profile-page").expect_err("relative URI relation type");
+
+        assert!(error.to_string().contains("invalid relation type"));
+    }
+
+    #[test]
+    fn rejects_uri_relation_types_with_malformed_percent_escapes() {
+        let error = Rel::try_new("http://example.com/a%GG").expect_err("malformed percent escape");
 
         assert!(error.to_string().contains("invalid relation type"));
     }

--- a/webfinger-rs/src/types/resource.rs
+++ b/webfinger-rs/src/types/resource.rs
@@ -22,6 +22,10 @@ pub enum ResourceError {
     /// The resource is an invalid HTTP or HTTPS URI.
     #[error(transparent)]
     InvalidHttpUri(#[from] http::uri::InvalidUri),
+
+    /// The resource is an HTTP or HTTPS URI without an authority.
+    #[error("HTTP and HTTPS resources must include an authority")]
+    MissingHttpAuthority,
 }
 
 /// A WebFinger resource URI.
@@ -29,10 +33,19 @@ pub enum ResourceError {
 /// RFC 7033 uses the `resource` query parameter for the query target, which is a URI rather than a
 /// relative reference. `Resource` stores that URI text after checking that it has an RFC 3986
 /// scheme and contains only ASCII URI text. Hierarchical `http` and `https` resources are also
-/// parsed with [`http::Uri`] so malformed authorities are rejected.
+/// required to use the `//authority` form from RFC 3986 section 3.2 before their host is exposed
+/// through [`Resource::host`].
 ///
 /// Common valid resources include `acct:carol@example.com` and
 /// `https://example.org/users/carol`.
+///
+/// See [RFC 7033 section 4.1] for the `resource` parameter, [RFC 3986 section 2.1] for percent
+/// encoding, [RFC 3986 section 3.1] for URI schemes, and [RFC 3986 section 3.2] for authority.
+///
+/// [RFC 7033 section 4.1]: https://www.rfc-editor.org/rfc/rfc7033.html#section-4.1
+/// [RFC 3986 section 2.1]: https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1
+/// [RFC 3986 section 3.1]: https://www.rfc-editor.org/rfc/rfc3986.html#section-3.1
+/// [RFC 3986 section 3.2]: https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Resource {
     text: String,
@@ -119,8 +132,17 @@ fn validate_resource(resource: &str) -> Result<Option<String>, ResourceError> {
     }
     validate_percent_escapes(resource)?;
     if scheme.eq_ignore_ascii_case("http") || scheme.eq_ignore_ascii_case("https") {
+        // WebFinger only needs host inference for hierarchical HTTP(S) resources. RFC 3986
+        // section 3.2 attaches an authority to URIs that begin their hier-part with `//`; opaque
+        // forms like `http:foo` must not produce a synthetic host.
+        if !resource[scheme.len()..].starts_with("://") {
+            return Err(ResourceError::MissingHttpAuthority);
+        }
         let uri = Uri::try_from(resource).map_err(ResourceError::InvalidHttpUri)?;
-        return Ok(uri.host().map(str::to_string));
+        let Some(host) = uri.host() else {
+            return Err(ResourceError::MissingHttpAuthority);
+        };
+        return Ok(Some(host.to_string()));
     }
     Ok(None)
 }
@@ -237,6 +259,19 @@ mod tests {
             matches!(error, ResourceError::InvalidPercentEncoding),
             "expected invalid-percent-encoding error, got {error:?}",
         );
+    }
+
+    /// Rejects HTTP and HTTPS resources that omit the required authority.
+    #[test]
+    fn rejects_http_resources_without_authority() {
+        for resource in ["http:foo", "https:foo", "http:/example.org/path"] {
+            let error = resource.parse::<Resource>().unwrap_err();
+
+            assert!(
+                matches!(error, ResourceError::MissingHttpAuthority),
+                "expected missing-authority error for {resource:?}, got {error:?}",
+            );
+        }
     }
 
     /// Validates HTTP and HTTPS resource authorities regardless of scheme case.


### PR DESCRIPTION
## Summary

- reject non-hierarchical `http:`/`https:` WebFinger resources before host inference
- reject malformed percent escapes in JRD URI fields and URI-valued relation types
- document the RFC 3986/RFC 7033 rationale for the stricter URI validators

## Validation

- `cargo fmt --all --check`
- `cargo test -p webfinger-rs --all-features`
- `cargo test -p webfinger-cli`
