### PR TITLE
fix: encode WebFinger query values

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A request built by this crate today for `acct:carol@example.com` filtered to the
 relation looks like this:
 
 ```text
-GET https://example.com/.well-known/webfinger?resource=acct:carol@example.com&rel=http://webfinger.net/rel/profile-page
+GET https://example.com/.well-known/webfinger?resource=acct%3Acarol%40example.com&rel=http%3A%2F%2Fwebfinger.net%2Frel%2Fprofile-page
 ```
 
 Server integrations split that contract across the normal web-framework boundary:

--- a/webfinger-rs/src/http.rs
+++ b/webfinger-rs/src/http.rs
@@ -8,11 +8,13 @@ use crate::{WELL_KNOWN_PATH, WebFingerRequest, WebFingerResponse};
 
 pub(crate) const CORS_ALLOW_ORIGIN: &str = "*";
 
-/// The set of values to percent encode
+/// The set of bytes to percent-encode in WebFinger query parameter values.
 ///
-/// Notably, this set does not include the `@`, `:`, `?`, and `/` characters which are allowed by
-/// RFC 3986 in the query component. It does include `%` so already-percent-encoded resource or
-/// relation URIs survive WebFinger query parsing as literal percent escapes in the target value.
+/// RFC 7033 section 4.1 percent-encodes the `resource` and `rel` parameter values before placing
+/// them in the query component. Only RFC 3986 unreserved characters are left literal here, which
+/// matches the RFC examples and keeps URI delimiters inside parameter values unambiguous. The set
+/// includes `%` so already-percent-encoded resource or relation URIs survive WebFinger query
+/// parsing as literal percent escapes in the target value.
 ///
 /// See the following RFCs for more information:
 /// - <https://www.rfc-editor.org/rfc/rfc7033#section-4.1>
@@ -23,13 +25,27 @@ pub(crate) const CORS_ALLOW_ORIGIN: &str = "*";
 /// Note: this may be implemented in the `percent-encoding` crate soon in
 /// <https://github.com/servo/rust-url/pull/971>
 const QUERY: AsciiSet = percent_encoding::CONTROLS
-    // RFC 3986
     .add(b' ')
+    .add(b'!')
     .add(b'"')
     .add(b'#')
+    .add(b'$')
     .add(b'%')
+    .add(b'&')
+    .add(b'\'')
+    .add(b'(')
+    .add(b')')
+    .add(b'*')
+    .add(b'+')
+    .add(b',')
+    .add(b'/')
+    .add(b':')
+    .add(b';')
     .add(b'<')
+    .add(b'=')
     .add(b'>')
+    .add(b'?')
+    .add(b'@')
     .add(b'[')
     .add(b'\\')
     .add(b']')
@@ -37,10 +53,7 @@ const QUERY: AsciiSet = percent_encoding::CONTROLS
     .add(b'`')
     .add(b'{')
     .add(b'|')
-    .add(b'}')
-    // RFC 7033
-    .add(b'=')
-    .add(b'&');
+    .add(b'}');
 
 impl TryFrom<&WebFingerRequest> for PathAndQuery {
     type Error = InvalidUri;
@@ -114,7 +127,7 @@ mod tests {
 
         assert_eq!(
             uri.to_string(),
-            "https://example.org/.well-known/webfinger?resource=https://example.org/profile/a%2520b",
+            "https://example.org/.well-known/webfinger?resource=https%3A%2F%2Fexample.org%2Fprofile%2Fa%2520b",
         );
     }
 
@@ -137,7 +150,7 @@ mod tests {
 
         assert_eq!(
             uri.to_string(),
-            "https://example.org/.well-known/webfinger?resource=acct:carol@example.org&rel=https://example.org/rel/a%252Fb",
+            "https://example.org/.well-known/webfinger?resource=acct%3Acarol%40example.org&rel=https%3A%2F%2Fexample.org%2Frel%2Fa%252Fb",
         );
     }
 }

--- a/webfinger-rs/src/lib.rs
+++ b/webfinger-rs/src/lib.rs
@@ -75,7 +75,7 @@
 //! relation looks like this:
 //!
 //! ```text
-//! GET https://example.com/.well-known/webfinger?resource=acct:carol@example.com&rel=http://webfinger.net/rel/profile-page
+//! GET https://example.com/.well-known/webfinger?resource=acct%3Acarol%40example.com&rel=http%3A%2F%2Fwebfinger.net%2Frel%2Fprofile-page
 //! ```
 //!
 //! See: [RFC 7033 section 4.1] for the query-construction rules and percent-encoding details.

--- a/webfinger-rs/src/reqwest.rs
+++ b/webfinger-rs/src/reqwest.rs
@@ -164,7 +164,7 @@ impl WebFingerRequest {
     /// assert_eq!(reqwest_request.method(), reqwest::Method::GET);
     /// assert_eq!(
     ///     reqwest_request.url().as_str(),
-    ///     "https://example.com/.well-known/webfinger?resource=acct:carol@example.com&rel=http://webfinger.net/rel/profile-page"
+    ///     "https://example.com/.well-known/webfinger?resource=acct%3Acarol%40example.com&rel=http%3A%2F%2Fwebfinger.net%2Frel%2Fprofile-page"
     /// );
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```

--- a/webfinger-rs/src/types/request.rs
+++ b/webfinger-rs/src/types/request.rs
@@ -31,7 +31,7 @@ use crate::{Error, Rel, Resource};
 /// maps to this URL shape:
 ///
 /// ```text
-/// https://example.com/.well-known/webfinger?resource=acct:carol@example.com&rel=http://webfinger.net/rel/profile-page&rel=http://webfinger.net/rel/avatar
+/// https://example.com/.well-known/webfinger?resource=acct%3Acarol%40example.com&rel=http%3A%2F%2Fwebfinger.net%2Frel%2Fprofile-page&rel=http%3A%2F%2Fwebfinger.net%2Frel%2Favatar
 /// ```
 ///
 /// `host` is required when you want to turn the request into an outgoing HTTP request, because the
@@ -249,7 +249,7 @@ impl Builder {
     ///
     /// assert_eq!(
     ///     uri.to_string(),
-    ///     "https://example.com/.well-known/webfinger?resource=acct:carol@example.com&rel=http://webfinger.net/rel/profile-page",
+    ///     "https://example.com/.well-known/webfinger?resource=acct%3Acarol%40example.com&rel=http%3A%2F%2Fwebfinger.net%2Frel%2Fprofile-page",
     /// );
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -270,7 +270,7 @@ impl Builder {
     ///
     /// assert_eq!(
     ///     uri.to_string(),
-    ///     "https://example.com/.well-known/webfinger?resource=acct:carol@example.com&rel=http://webfinger.net/rel/profile-page&rel=http://webfinger.net/rel/avatar",
+    ///     "https://example.com/.well-known/webfinger?resource=acct%3Acarol%40example.com&rel=http%3A%2F%2Fwebfinger.net%2Frel%2Fprofile-page&rel=http%3A%2F%2Fwebfinger.net%2Frel%2Favatar",
     /// );
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -298,12 +298,9 @@ mod tests {
         };
         let uri = Uri::try_from(&query).unwrap();
 
-        // The RFC unnecessarily percent-encodes this to:
-        // `"/.well-known/webfinger?resource=acct%3Acarol%40example.com&rel=http%3A%2F%2Fopenid.net%
-        // 2Fspecs%2Fconnect%2F1.0%2Fissuer"`
         assert_eq!(
             uri.to_string(),
-            "https://example.com/.well-known/webfinger?resource=acct:carol@example.com&rel=http://openid.net/specs/connect/1.0/issuer",
+            "https://example.com/.well-known/webfinger?resource=acct%3Acarol%40example.com&rel=http%3A%2F%2Fopenid.net%2Fspecs%2Fconnect%2F1.0%2Fissuer",
         );
     }
 
@@ -318,11 +315,9 @@ mod tests {
         };
         let uri = Uri::try_from(&query).unwrap();
 
-        // The RFC unnecessarily percent-encodes this to:
-        // /.well-known/webfinger?resource=http%3A%2F%2Fblog.example.com%2Farticle%2Fid%2F314
         assert_eq!(
             uri.to_string(),
-            "https://blog.example.com/.well-known/webfinger?resource=http://blog.example.com/article/id/314",
+            "https://blog.example.com/.well-known/webfinger?resource=http%3A%2F%2Fblog.example.com%2Farticle%2Fid%2F314",
         );
     }
 }


### PR DESCRIPTION
## Summary

- match RFC 7033 examples by percent-encoding WebFinger query parameter values with only RFC 3986 unreserved characters left literal
- update request tests, reqwest docs, crate docs, and README examples to show the encoded URL shape
- remove stale comments that described the RFC examples as unnecessarily encoded

Closes #131

## Verification

- cargo fmt --all --check
- cargo test --workspace
- cargo test --locked --all-features --doc
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- markdownlint-cli2

Blocked locally:

- just docs-rs: missing x86_64-linux-gnu-gcc for the docs.rs Linux target C dependencies
- cargo rdme --check --workspace-project webfinger-rs: missing nightly-2026-06-22 for intralink resolution
