### PR TITLE
Fix local viewer lookup policy

### DIFF
--- a/webfinger-viewer-worker/README.md
+++ b/webfinger-viewer-worker/README.md
@@ -13,9 +13,13 @@ public deployments constrained to the hostname that served the viewer.
 Public deployments are same-origin by default: a viewer served from `https://example.com/webfinger`
 can inspect `https://example.com/.well-known/webfinger`, but it rejects lookups for unrelated
 hosts. Local Wrangler sessions are the exception. When the viewer itself is served from
-`localhost`, `127.0.0.1`, or `::1`, full loopback WebFinger URLs are allowed so a local viewer on
-port `8788` can inspect another local Worker on a port such as `8787`. In a deployed Cloudflare
-Worker, `localhost` refers to the Worker runtime environment, not the developer machine.
+`localhost`, `127.0.0.1`, or `::1`, off-origin lookups are allowed so a local viewer can inspect
+public resources such as `acct:joshka@hachyderm.io` and another local Worker on a port such as
+`8787`. Plain loopback resources such as `acct:alice@localhost` derive
+`http://localhost:8787/.well-known/webfinger`, and loopback full URLs entered as
+`https://localhost:8787/...` are normalized to `http://localhost:8787/...` because Wrangler dev
+serves plain HTTP. In a deployed Cloudflare Worker, `localhost` refers to the Worker runtime
+environment, not the developer machine.
 
 ## Features
 
@@ -23,6 +27,10 @@ Worker, `localhost` refers to the Worker runtime environment, not the developer 
   `example.com`.
 - Accepts full WebFinger URLs such as
   `https://example.com/.well-known/webfinger?resource=acct:alice@example.com`.
+- Accepts arbitrary resource hosts during local Wrangler development, including
+  `acct:joshka@hachyderm.io`.
+- Maps local resource identifiers such as `acct:alice@localhost` and `acct:alice@127.0.0.1` to the
+  default local responder port `8787`.
 - Accepts full loopback WebFinger URLs during local Wrangler development, such as
   `http://127.0.0.1:8787/.well-known/webfinger?resource=acct%3Aalice%40localhost`.
 - Adds optional repeated `rel` filters to the target request.
@@ -81,12 +89,31 @@ npm run dev
 Then open the local Wrangler URL and query a resource such as:
 
 ```text
+acct:joshka@hachyderm.io
+```
+
+To inspect a local WebFinger responder running on another Wrangler port, query the full target URL:
+
+```text
 http://127.0.0.1:8787/.well-known/webfinger?resource=acct%3Aalice%40localhost
 ```
 
-That full URL shape lets a viewer on one local Wrangler port inspect a WebFinger responder running
-on another local Wrangler port. Plain resource inputs are same-origin, so deployed pages should use
-resources whose host matches the page host.
+For the common local responder port, plain loopback resources also work:
+
+```text
+acct:alice@localhost
+acct:alice@127.0.0.1
+```
+
+If you type the standard HTTPS form for a loopback Wrangler target, local mode normalizes it to
+HTTP before fetching because Wrangler dev serves plain HTTP:
+
+```text
+https://localhost:8787/.well-known/webfinger?resource=acct%3Aalice%40localhost
+```
+
+Production deployments should use resources whose host matches the page host. Local Wrangler
+sessions are intentionally more permissive because they are a developer debugging surface.
 
 ## Implementation Map
 
@@ -114,9 +141,9 @@ authentication; direct clients can spoof htmx and Fetch Metadata headers. They k
 contract narrow and avoid CORS-enabled use of the Worker as a general server-side lookup endpoint.
 
 Lookup input is bounded before the Worker fetches a target: resource strings, relation filter
-count, relation filter length, final target URL length, same-origin target policy, and captured
-response body size all have explicit limits. Response headers also set a restrictive baseline for
-browser use, including
+count, relation filter length, final target URL length, target policy, and captured response body
+size all have explicit limits. Response headers also set a restrictive baseline for browser use,
+including
 `Content-Security-Policy`, `X-Content-Type-Options`, `Referrer-Policy`, and `Permissions-Policy`.
 The CSP allows inline script and style because the Worker embeds htmx, CSS, and local JavaScript in
 one path-mounted page response; it still blocks remote scripts, framing, base URI changes, and

--- a/webfinger-viewer-worker/src/lookup/policy.rs
+++ b/webfinger-viewer-worker/src/lookup/policy.rs
@@ -1,8 +1,9 @@
 //! Deployment policy for target WebFinger fetches.
 //!
 //! Public deployments are same-origin by default so the viewer remains a debugging UI for the site
-//! that serves it, not an unrestricted server-side fetch proxy. Local Wrangler development gets a
-//! narrow loopback exception so a viewer on one localhost port can inspect a responder on another.
+//! that serves it, not an unrestricted server-side fetch proxy. Local Wrangler development gets an
+//! off-origin exception so the local viewer can inspect arbitrary public resources and local
+//! responders without relaxing production deployments.
 
 use url::Url;
 
@@ -12,28 +13,37 @@ use super::LookupError;
 ///
 /// Public deployments are same-origin by default: the viewer may only fetch the WebFinger endpoint
 /// for the host that served the UI. When the viewer itself is running on loopback under
-/// `wrangler dev`, loopback target URLs are also allowed so a local viewer on port `8788` can
-/// inspect a local WebFinger server on another port such as `8787`. This keeps production behavior
-/// conservative without requiring checked-in environment files for local development.
+/// `wrangler dev`, off-origin targets are allowed so a local viewer can inspect public WebFinger
+/// resources such as `acct:joshka@hachyderm.io` and local servers on another port. This keeps
+/// production behavior conservative without requiring checked-in environment files for local
+/// development.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LookupPolicy {
     viewer_origin: Origin,
-    allow_loopback_targets: bool,
+    allow_off_origin_targets: bool,
 }
 
 impl LookupPolicy {
+    /// Default local responder port used for loopback `acct:` resources in Wrangler development.
+    ///
+    /// A plain WebFinger resource such as `acct:alice@localhost` does not contain a port. During
+    /// local development the common repo workflow is a viewer Worker on one Wrangler port and a
+    /// responder Worker on `8787`, so the viewer maps loopback resource identifiers there. Use a
+    /// full WebFinger URL when debugging a different local port.
+    pub const LOCAL_RESPONDER_PORT: u16 = 8787;
+
     /// Builds lookup policy from the request that served `/api/lookup`.
     ///
     /// The request URL is the only configuration source on purpose. This Worker is meant to be a
     /// reusable tool that can be deployed under different hostnames without editing repo-local env
     /// files. Validate the behavior by changing only the request host: production-like hosts reject
-    /// off-origin targets, while loopback hosts allow loopback WebFinger URLs for local testing.
+    /// off-origin targets, while loopback hosts allow arbitrary targets for local testing.
     pub fn from_viewer_url(url: &Url) -> Self {
         let viewer_origin = Origin::from_url(url);
-        let allow_loopback_targets = viewer_origin.host_is_loopback();
+        let allow_off_origin_targets = viewer_origin.host_is_loopback();
         Self {
             viewer_origin,
-            allow_loopback_targets,
+            allow_off_origin_targets,
         }
     }
 
@@ -43,13 +53,45 @@ impl LookupPolicy {
         if target_origin.same_origin(&self.viewer_origin) {
             return Ok(());
         }
-        if self.allow_loopback_targets && target_origin.host_is_loopback() {
+        if self.allow_off_origin_targets {
             return Ok(());
         }
 
         Err(LookupError::OffOriginTarget {
             allowed_host: self.viewer_origin.host_for_message(),
         })
+    }
+
+    /// Returns true when the viewer request came from a local Wrangler-style origin.
+    ///
+    /// This is intentionally derived from the request URL instead of a checked-in environment file.
+    /// Local mode is more permissive because the developer is using a loopback-only viewer to debug
+    /// arbitrary public resources and local responders.
+    pub fn is_local_development(&self) -> bool {
+        self.allow_off_origin_targets
+    }
+
+    /// Returns true when a host is one of the loopback spellings supported by local development.
+    pub fn host_is_loopback(host: &str) -> bool {
+        Origin::host_name_is_loopback(host)
+    }
+
+    /// Builds the default local responder origin for an inferred loopback resource host.
+    ///
+    /// `acct:` resources cannot carry a port. When the viewer is local and the resource host is
+    /// loopback, derive an HTTP target on `LOCAL_RESPONDER_PORT` so `acct:alice@localhost` can
+    /// exercise the companion responder Worker during development.
+    pub fn local_responder_origin_for_host(&self, host: &str) -> Option<String> {
+        if !self.is_local_development() || !Self::host_is_loopback(host) {
+            return None;
+        }
+
+        let host = if host == "::1" {
+            "[::1]".to_string()
+        } else {
+            host.to_string()
+        };
+        Some(format!("http://{host}:{}", Self::LOCAL_RESPONDER_PORT))
     }
 }
 
@@ -85,7 +127,15 @@ impl Origin {
     /// the browser. It does not try to classify every private or special-purpose IP range because
     /// production deployments should stay same-origin unless the viewer itself is running locally.
     fn host_is_loopback(&self) -> bool {
-        matches!(self.host.as_str(), "localhost" | "127.0.0.1" | "::1")
+        Self::host_name_is_loopback(&self.host)
+    }
+
+    /// Returns true for a normalized host name that refers to loopback.
+    fn host_name_is_loopback(host: &str) -> bool {
+        matches!(
+            host.to_ascii_lowercase().as_str(),
+            "localhost" | "127.0.0.1" | "::1"
+        )
     }
 
     /// Formats the allowed host for user-facing policy errors.
@@ -165,6 +215,21 @@ mod tests {
         assert_eq!(
             request.target_url().as_str(),
             "http://127.0.0.1:8787/.well-known/webfinger?resource=acct%3Aalice%40localhost",
+        );
+    }
+
+    #[test]
+    fn allows_external_resource_from_local_viewer() {
+        let request = LookupRequest::new(
+            "acct:joshka@hachyderm.io".to_string(),
+            Vec::new(),
+            &local_policy(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            request.target_url().as_str(),
+            "https://hachyderm.io/.well-known/webfinger?resource=acct%3Ajoshka%40hachyderm.io",
         );
     }
 

--- a/webfinger-viewer-worker/src/lookup/request.rs
+++ b/webfinger-viewer-worker/src/lookup/request.rs
@@ -66,8 +66,10 @@ impl LookupRequest {
     /// Builds a lookup request from validated viewer input.
     ///
     /// Full WebFinger URLs preserve their original endpoint unless the caller supplies new `rel`
-    /// filters. Resource identifiers derive their endpoint from the resource host and always use
-    /// HTTPS, matching RFC 7033 discovery expectations for normal viewer input.
+    /// filters. Resource identifiers normally derive an HTTPS endpoint from the resource host,
+    /// matching RFC 7033 discovery expectations. Local Wrangler development is the exception:
+    /// loopback full URLs are normalized to HTTP, and loopback resource identifiers derive
+    /// `http://<host>:8787` so they can reach a companion local responder Worker.
     pub fn new(
         resource: String,
         rels: Vec<String>,
@@ -77,10 +79,10 @@ impl LookupRequest {
         validate_rels(&rels)?;
 
         let target_url = if points_at_webfinger_endpoint(&resource) {
-            webfinger_url(&resource, &rels)?
+            webfinger_url(&resource, &rels, policy)?
         } else {
             let _validated = resource.parse::<Resource>()?;
-            resource_url(&resource, &rels)?
+            resource_url(&resource, &rels, policy)?
         };
         validate_target_url(&target_url)?;
         policy.validate_target(&target_url)?;
@@ -125,7 +127,7 @@ fn points_at_webfinger_endpoint(input: &str) -> bool {
 /// A full URL is useful when debugging an exact endpoint or reproducing another client's request.
 /// If the viewer supplies `rel` filters, they replace the URL's existing `rel` parameters so the UI
 /// has one obvious source of truth for active filters.
-fn webfinger_url(input: &str, rels: &[String]) -> Result<Url, LookupError> {
+fn webfinger_url(input: &str, rels: &[String], policy: &LookupPolicy) -> Result<Url, LookupError> {
     let mut url = Url::parse(input)?;
     if url.path() != WELL_KNOWN_PATH {
         return Err(LookupError::NotWebFingerUrl);
@@ -133,6 +135,7 @@ fn webfinger_url(input: &str, rels: &[String]) -> Result<Url, LookupError> {
     if !matches!(url.scheme(), "https" | "http") {
         return Err(LookupError::UnsupportedScheme(url.scheme().to_string()));
     }
+    normalize_local_loopback_scheme(&mut url, policy)?;
 
     let resource = url
         .query_pairs()
@@ -155,12 +158,20 @@ fn webfinger_url(input: &str, rels: &[String]) -> Result<Url, LookupError> {
 
 /// Builds the standard WebFinger endpoint URL for a resource identifier.
 ///
-/// The viewer always derives HTTPS endpoints for plain resource input. Use the full WebFinger URL
-/// input path when debugging a non-standard scheme, host, or query string exactly as supplied by
-/// another client.
-fn resource_url(resource: &str, rels: &[String]) -> Result<Url, LookupError> {
+/// The viewer derives HTTPS endpoints for normal resource input. In local development, loopback
+/// hosts use the repo's default local responder origin so `acct:alice@localhost` reaches
+/// `http://localhost:8787/.well-known/webfinger`. Use the full WebFinger URL input path when
+/// debugging a different local port or an exact query string from another client.
+fn resource_url(
+    resource: &str,
+    rels: &[String],
+    policy: &LookupPolicy,
+) -> Result<Url, LookupError> {
     let host = resource_host(resource)?;
-    let mut url = Url::parse(&format!("https://{host}{WELL_KNOWN_PATH}"))?;
+    let origin = policy
+        .local_responder_origin_for_host(&host)
+        .unwrap_or_else(|| format!("https://{host}"));
+    let mut url = Url::parse(&format!("{origin}{WELL_KNOWN_PATH}"))?;
     {
         let mut query = url.query_pairs_mut();
         query.append_pair("resource", resource);
@@ -169,6 +180,29 @@ fn resource_url(resource: &str, rels: &[String]) -> Result<Url, LookupError> {
         }
     }
     Ok(url)
+}
+
+/// Normalizes loopback HTTPS URLs to HTTP during local Wrangler development.
+///
+/// Wrangler dev servers listen on plain HTTP. This viewer accepts `https://localhost:8787/...`
+/// because it is the standard WebFinger shape many people type first, but local mode rewrites that
+/// target to `http://localhost:8787/...` before the Worker fetches it. Production-like deployments
+/// never rewrite schemes.
+fn normalize_local_loopback_scheme(
+    url: &mut Url,
+    policy: &LookupPolicy,
+) -> Result<(), LookupError> {
+    if !policy.is_local_development() || url.scheme() != "https" {
+        return Ok(());
+    }
+    let Some(host) = url.host_str() else {
+        return Ok(());
+    };
+    if LookupPolicy::host_is_loopback(host) {
+        url.set_scheme("http")
+            .map_err(|_| LookupError::UnsupportedScheme(url.scheme().to_string()))?;
+    }
+    Ok(())
 }
 
 /// Validates the user-visible resource before target URL construction.
@@ -247,6 +281,12 @@ mod tests {
         )
     }
 
+    fn local_policy() -> LookupPolicy {
+        LookupPolicy::from_viewer_url(
+            &Url::parse("http://localhost:8790/webfinger/api/lookup").unwrap(),
+        )
+    }
+
     #[test]
     fn builds_acct_target_url() {
         let request = LookupRequest::new(
@@ -290,6 +330,52 @@ mod tests {
         assert_eq!(
             request.target_url().as_str(),
             "https://example.com/.well-known/webfinger?resource=acct%3Aalice%40example.com",
+        );
+    }
+
+    #[test]
+    fn local_viewer_derives_loopback_acct_resource_to_default_responder_port() {
+        let request = LookupRequest::new(
+            "acct:alice@localhost".to_string(),
+            Vec::new(),
+            &local_policy(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            request.target_url().as_str(),
+            "http://localhost:8787/.well-known/webfinger?resource=acct%3Aalice%40localhost",
+        );
+    }
+
+    #[test]
+    fn local_viewer_derives_ipv4_loopback_acct_resource_to_default_responder_port() {
+        let request = LookupRequest::new(
+            "acct:alice@127.0.0.1".to_string(),
+            Vec::new(),
+            &local_policy(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            request.target_url().as_str(),
+            "http://127.0.0.1:8787/.well-known/webfinger?resource=acct%3Aalice%40127.0.0.1",
+        );
+    }
+
+    #[test]
+    fn local_viewer_normalizes_https_loopback_webfinger_url_to_http() {
+        let request = LookupRequest::new(
+            "https://localhost:8787/.well-known/webfinger?resource=acct%3Aalice%40localhost"
+                .to_string(),
+            Vec::new(),
+            &local_policy(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            request.target_url().as_str(),
+            "http://localhost:8787/.well-known/webfinger?resource=acct%3Aalice%40localhost",
         );
     }
 


### PR DESCRIPTION
## Summary

- allow loopback-hosted viewer sessions to inspect arbitrary WebFinger targets while keeping production deployments same-origin
- map `acct:*@localhost` and `acct:*@127.0.0.1` to the default local responder port `8787`
- normalize local loopback `https://localhost:8787/...` WebFinger URLs to `http://localhost:8787/...` for Wrangler dev
- document the local-vs-production lookup behavior

## Validation

- `cargo fmt --all --check`
- `cargo test -p webfinger-viewer-worker`
- `cargo check -p webfinger-viewer-worker --target wasm32-unknown-unknown`
- `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- `markdownlint-cli2 --no-globs README.md webfinger-viewer-worker/README.md`
- `typos`
- `npm run deploy:dry-run`
- browser check with a temporary responder on `127.0.0.1:8787`
