### PR TITLE
Route viewer fetches through Cloudflare

### DIFF
--- a/webfinger-viewer-worker/README.md
+++ b/webfinger-viewer-worker/README.md
@@ -44,6 +44,12 @@ environment, not the developer machine.
 The Worker can be mounted below a path such as `/webfinger`. It still queries the standard target
 path on the same host, such as `https://example.com/.well-known/webfinger`.
 
+The checked-in Wrangler config enables Cloudflare's `global_fetch_strictly_public` compatibility
+flag. Public deployments need this because the viewer performs server-side `fetch()` calls back to
+the same zone. Without the flag, Cloudflare can route that subrequest to the zone origin while
+ignoring same-zone Worker routes, which appears in the viewer as a target `522` even though the same
+`/.well-known/webfinger` URL works from a browser or local `curl`.
+
 1. Install the local JavaScript tooling:
 
 ```console

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,7 @@
 name = "webfinger-viewer-worker"
 main = "webfinger-viewer-worker/build/worker/shim.mjs"
 compatibility_date = "2026-07-02"
+compatibility_flags = ["global_fetch_strictly_public"]
 
 [build]
 command = "scripts/build-webfinger-viewer-worker.sh"


### PR DESCRIPTION
## Summary

- enable Cloudflare's `global_fetch_strictly_public` compatibility flag for the viewer Worker
- document why same-zone server-side WebFinger fetches need public routing on deployed routes
- install a console-backed `tracing` subscriber for wasm Worker builds so viewer request and lookup breadcrumbs appear in Wrangler tail and Cloudflare dashboard logs

## Context

The deployed viewer at `https://joshmck.net/webfinger` could show a target `522` for `acct:joshka@joshmck.net`, while direct `curl` to `https://joshmck.net/.well-known/webfinger?...` returned `200`. That points at Cloudflare's same-zone Worker `fetch()` behavior: without `global_fetch_strictly_public`, a Worker subrequest to its own zone can bypass Worker routes and go to origin, which is not what this viewer needs when it is debugging the same host.

The Worker already had observability enabled in `wrangler.toml`, but it now also emits explicit `tracing` events for request routing decisions, lookup results, malformed lookup input, and Worker-side fetch failures.

## Validation

- `cargo fmt --all --check`
- `cargo test -p webfinger-viewer-worker`
- `cargo check -p webfinger-viewer-worker --target wasm32-unknown-unknown`
- `markdownlint-cli2 --no-globs webfinger-viewer-worker/README.md`
- `npm run deploy:dry-run`
