### PR TITLE
Add viewer Worker logs and refresh loading state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2713,6 +2713,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-web"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e6a141feebd51f8d91ebfd785af50fca223c570b86852166caa3b141defe7c"
+dependencies = [
+ "js-sys",
+ "tracing-core",
+ "tracing-subscriber",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2947,6 +2960,8 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-subscriber",
+ "tracing-web",
  "url",
  "web-sys",
  "webfinger-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,8 @@ tokio = { version = "1.41", default-features = false }
 tower = "0.5.2"
 tower-http = { version = "0.7.0" }
 tracing = { version = "0.1.37", default-features = false, features = ["attributes", "std"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "env-filter", "fmt"] }
+tracing-subscriber = { version = "0.3.15", default-features = false, features = ["ansi", "env-filter", "fmt"] }
+tracing-web = "0.1.3"
 url = "2.5"
 web-sys = { version = "0.3.102", features = ["Response"] }
 webfinger-rs = { path = "webfinger-rs", version = "0.0.31" }

--- a/webfinger-viewer-worker/Cargo.toml
+++ b/webfinger-viewer-worker/Cargo.toml
@@ -21,10 +21,14 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+tracing-subscriber.workspace = true
 url.workspace = true
 web-sys.workspace = true
 webfinger-rs.workspace = true
 worker = { workspace = true, features = ["http"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+tracing-web.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/webfinger-viewer-worker/README.md
+++ b/webfinger-viewer-worker/README.md
@@ -92,6 +92,17 @@ The repository intentionally does not use a root `rust-toolchain.toml`: the libr
 uses nightly for docs.rs-only Rustdoc features, while the Worker deploy hook can bootstrap stable
 Rust by itself.
 
+## Observability
+
+`wrangler.toml` enables Cloudflare Worker observability. The Worker installs a console-backed
+`tracing` subscriber in wasm builds, so request decisions and lookup results appear in Wrangler tail
+and Cloudflare dashboard logs. Useful log events include:
+
+- `webfinger viewer request` with `method`, `path`, and a stable `outcome` value.
+- `webfinger lookup result` with target status, target URL, resource, content type, and truncation
+  state.
+- lookup input and Worker-fetch errors at error level.
+
 ## Local Development
 
 Run Wrangler locally:

--- a/webfinger-viewer-worker/assets/app.css
+++ b/webfinger-viewer-worker/assets/app.css
@@ -289,6 +289,18 @@ button:disabled {
   color: var(--bad);
 }
 
+.loading-state {
+  display: none;
+}
+
+.loading-state.htmx-request {
+  display: inline;
+}
+
+.loading-state.htmx-request + #state {
+  display: none;
+}
+
 .shell {
   display: grid;
   gap: 12px;

--- a/webfinger-viewer-worker/assets/app.js
+++ b/webfinger-viewer-worker/assets/app.js
@@ -1,13 +1,12 @@
 // Small browser-only behavior for the viewer shell.
 //
 // htmx owns lookup submission and result swapping. Keep this file limited to behavior that is local
-// to the browser: theme persistence, path-prefix-aware API targeting, loading state, and clipboard
-// buttons. Parsed JRD rendering belongs in Rust view models and Askama templates.
+// to the browser: theme persistence, path-prefix-aware API targeting, context-sensitive
+// placeholders, and clipboard buttons. Parsed JRD rendering and lookup lifecycle state belong to
+// Rust view models, Askama templates, and htmx attributes.
 
-const state = document.querySelector("#state");
 const form = document.querySelector("#lookup-form");
 const resourceInput = document.querySelector("#resource");
-const submit = document.querySelector("#submit");
 const themeSelect = document.querySelector("#theme");
 const themeStorageKey = "webfinger-viewer-theme";
 
@@ -64,20 +63,6 @@ async function copy(text) {
 
 form.setAttribute("hx-get", apiPath());
 resourceInput.setAttribute("placeholder", resourcePlaceholder());
-
-// While htmx owns the request, the surrounding shell owns the global loading indicator.
-//
-// Target WebFinger status is rendered by the response fragment after the request completes. This
-// transient state only tells the user that the Worker lookup is in flight.
-document.body.addEventListener("htmx:beforeRequest", () => {
-  submit.disabled = true;
-  state.textContent = "Fetching";
-  state.className = "state-text warn";
-});
-
-document.body.addEventListener("htmx:afterRequest", () => {
-  submit.disabled = false;
-});
 
 themeSelect.addEventListener("change", () => applyTheme(themeSelect.value));
 

--- a/webfinger-viewer-worker/src/lib.rs
+++ b/webfinger-viewer-worker/src/lib.rs
@@ -18,6 +18,7 @@
 //! resource's host.
 
 mod lookup;
+mod observability;
 mod server;
 mod view;
 
@@ -34,5 +35,6 @@ async fn fetch(
     env: ::worker::Env,
     ctx: ::worker::Context,
 ) -> ::worker::Result<::worker::Response> {
+    observability::init();
     server::serve(request, env, ctx).await
 }

--- a/webfinger-viewer-worker/src/lookup.rs
+++ b/webfinger-viewer-worker/src/lookup.rs
@@ -40,6 +40,7 @@ pub async fn fetch_webfinger(request: &LookupRequest) -> Result<LookupResult, Lo
     let content_type = response.headers().get("content-type")?;
     let redirect_location = response.headers().get("location")?;
     let body = read_capped_body(&mut response).await?;
+    log_lookup_result(request, status, content_type.as_deref(), body.truncated);
 
     Ok(LookupResult::new(LookupResultParts {
         request_url: request.target_url().to_string(),
@@ -84,6 +85,28 @@ fn target_redirect_mode() -> RequestRedirect {
 /// protocol context without making `server` understand WebFinger internals.
 pub fn log_lookup_error(error: &LookupError) {
     error!(?error, "webfinger lookup failed");
+}
+
+/// Logs target fetch outcomes.
+///
+/// The wasm entrypoint installs a console-backed tracing subscriber, so these events appear in
+/// Wrangler tail and Cloudflare dashboard logs. Keep the fields low-cardinality enough to filter by
+/// status and target host while still preserving the exact URL needed to reproduce a WebFinger
+/// debugging failure.
+fn log_lookup_result(
+    request: &LookupRequest,
+    status: u16,
+    content_type: Option<&str>,
+    truncated: bool,
+) {
+    info!(
+        status,
+        target_url = %request.target_url(),
+        resource = %request.resource(),
+        content_type = content_type.unwrap_or(""),
+        truncated,
+        "webfinger lookup result",
+    );
 }
 
 /// Captured target body after enforcing the viewer's response-size limit.

--- a/webfinger-viewer-worker/src/observability.rs
+++ b/webfinger-viewer-worker/src/observability.rs
@@ -1,0 +1,36 @@
+//! Worker logging setup.
+//!
+//! Cloudflare Worker Logs capture messages written to the JavaScript console. The Rust code uses
+//! `tracing` for request and lookup breadcrumbs, so wasm builds install a console-backed tracing
+//! subscriber at the fetch boundary. Native tests do not need a global subscriber; leaving them
+//! unconfigured avoids fights with test harnesses or future crate-level tracing capture.
+
+/// Installs logging support for the current runtime.
+///
+/// This is intentionally safe to call for every fetch event. Worker isolates can handle many
+/// requests, but they can also be restarted at any time; a tiny idempotent initializer keeps the
+/// entrypoint simple and makes validation obvious: emit a `tracing::info!` event and confirm it
+/// appears in Wrangler tail or Cloudflare dashboard logs.
+pub fn init() {
+    #[cfg(target_arch = "wasm32")]
+    init_wasm_console_tracing();
+}
+
+#[cfg(target_arch = "wasm32")]
+fn init_wasm_console_tracing() {
+    use std::sync::Once;
+    use tracing_subscriber::prelude::*;
+
+    static INIT: Once = Once::new();
+
+    INIT.call_once(|| {
+        let fmt_layer = tracing_subscriber::fmt::layer()
+            .with_ansi(false)
+            .without_time()
+            .with_writer(tracing_web::MakeWebConsoleWriter::new());
+
+        let subscriber = tracing_subscriber::registry().with(fmt_layer);
+
+        let _ = tracing::subscriber::set_global_default(subscriber);
+    });
+}

--- a/webfinger-viewer-worker/src/server.rs
+++ b/webfinger-viewer-worker/src/server.rs
@@ -14,6 +14,7 @@
 //! fragment rather than encoded as the Worker response status.
 
 use ::worker::{Context, Env, Method, Request, Response};
+use tracing::{error, info};
 
 use crate::lookup::{LookupPolicy, LookupRequest, fetch_webfinger, log_lookup_error};
 use crate::view;
@@ -51,9 +52,11 @@ pub async fn serve(request: Request, _env: Env, _ctx: Context) -> worker::Result
     }
 
     if method == Method::Get || method == Method::Head {
+        log_viewer_request(&method, url.path(), "page");
         return html_response(&view::page());
     }
 
+    log_viewer_request(&method, url.path(), "method_not_allowed");
     text_response("method not allowed", 405)
 }
 
@@ -69,26 +72,33 @@ async fn serve_lookup(request: Request) -> worker::Result<Response> {
     let url = request.url()?;
 
     if !is_htmx_request(&request)? {
+        log_viewer_request(&method, url.path(), "lookup_not_htmx");
         return text_response("not found", 404);
     }
     if is_cross_site_request(&request)? {
+        log_viewer_request(&method, url.path(), "lookup_cross_site");
         return text_response("forbidden", 403);
     }
 
     if method != Method::Get {
+        log_viewer_request(&method, url.path(), "lookup_method_not_allowed");
         return text_response("method not allowed", 405);
     }
 
     let policy = LookupPolicy::from_viewer_url(&url);
     let request = match LookupRequest::from_url_query(&url, &policy) {
         Ok(request) => request,
-        Err(error) => return html_fragment_response(&view::lookup_error(&error.to_string())),
+        Err(error) => {
+            error!(%error, "webfinger lookup input error");
+            return html_fragment_response(&view::lookup_error(&error.to_string()));
+        }
     };
 
     let result = match fetch_webfinger(&request).await {
         Ok(result) => result,
         Err(error) => {
             log_lookup_error(&error);
+            error!(%error, "webfinger lookup worker error");
             return html_fragment_response(&view::lookup_error(&error.to_string()));
         }
     };
@@ -165,4 +175,14 @@ fn is_cross_site_request(request: &Request) -> worker::Result<bool> {
         request.headers().get("sec-fetch-site")?.as_deref(),
         Some("cross-site")
     ))
+}
+
+/// Logs Worker request handling decisions.
+///
+/// The wasm entrypoint installs a console-backed tracing subscriber, so these events appear in
+/// Wrangler tail and Cloudflare dashboard logs. Keep the outcome vocabulary stable so dashboard
+/// filters can answer "was the Worker hit" and "which guard rejected this request" without
+/// exposing headers or other browser metadata.
+fn log_viewer_request(method: &Method, path: &str, outcome: &str) {
+    info!(method = ?method, path, outcome, "webfinger viewer request");
 }

--- a/webfinger-viewer-worker/src/view.rs
+++ b/webfinger-viewer-worker/src/view.rs
@@ -66,8 +66,8 @@ pub fn lookup_result(result: &LookupResult) -> String {
 /// Use this for viewer-level failures such as malformed resources or Worker fetch errors.
 /// Non-htmx or cross-site callers are rejected by `server` before this rendering path.
 pub fn lookup_error(message: &str) -> String {
-    let state = StateView::bad(message);
-    let template = LookupErrorTemplate { state };
+    let state = StateView::bad("Failed");
+    let template = LookupErrorTemplate { state, message };
     template.render().expect("lookup error template renders")
 }
 
@@ -108,4 +108,23 @@ struct LookupResultTemplate<'a> {
 struct LookupErrorTemplate<'a> {
     /// Header state swapped out-of-band by htmx.
     state: StateView<'a>,
+
+    /// Full viewer-level error shown in the result body.
+    message: &'a str,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lookup_error_keeps_header_short_and_body_specific() {
+        let html = lookup_error("missing resource");
+
+        assert!(html.contains(
+            r#"<span id="state" class="state-text bad" hx-swap-oob="true">Failed</span>"#
+        ));
+        assert!(html.contains("<h2>Lookup Error</h2>"));
+        assert!(html.contains("missing resource"));
+    }
 }

--- a/webfinger-viewer-worker/templates/lookup_error.html
+++ b/webfinger-viewer-worker/templates/lookup_error.html
@@ -20,8 +20,12 @@
   </div>
   <div class="workspace">
     <section>
-      <div class="toolbar"><h2>Resource Details</h2></div>
-      <div class="list"><p class="empty">Lookup failed.</p></div>
+      <div class="toolbar"><h2>Lookup Error</h2></div>
+      <div class="list">
+        <p class="empty error-message copyable">
+          {{ message }}<button class="copy-value" type="button" data-copy="{{ message }}" aria-label="Copy value">Copy</button>
+        </p>
+      </div>
     </section>
   </div>
 </div>

--- a/webfinger-viewer-worker/templates/page.html
+++ b/webfinger-viewer-worker/templates/page.html
@@ -25,6 +25,7 @@
             <option value="dark">Dark</option>
           </select>
         </label>
+        <span id="state-loading" class="state-text warn loading-state">Fetching</span>
         <span id="state" class="state-text">Idle</span>
       </div>
     </header>
@@ -34,6 +35,7 @@
         <form
           id="lookup-form"
           hx-get="api/lookup"
+          hx-indicator="#state-loading"
           hx-target="#results"
           hx-swap="outerHTML"
         >


### PR DESCRIPTION
## Summary

- install a console-backed `tracing` subscriber for wasm Worker builds
- log viewer request routing decisions, lookup results, malformed lookup input, and Worker fetch failures
- document the emitted log events for Wrangler tail and Cloudflare dashboard checks
- use htmx's `hx-indicator` for the in-flight `Fetching` state so repeated fetches do not depend on cached DOM references

## Notes

`wrangler.toml` already enables Worker observability. This change makes the viewer emit useful events to the JavaScript console through `tracing-web`, which Cloudflare Worker Logs can capture.

## Validation

- `cargo fmt --all --check`
- `cargo test -p webfinger-viewer-worker`
- `cargo check -p webfinger-viewer-worker --target wasm32-unknown-unknown`
- `cargo minimal-versions check --direct --workspace --all-features --all-targets`
- `markdownlint-cli2 --no-globs webfinger-viewer-worker/README.md`
- `npm run deploy:dry-run`
