### PR TITLE
Polish viewer lookup diagnostics

### DIFF
--- a/webfinger-viewer-worker/assets/app.css
+++ b/webfinger-viewer-worker/assets/app.css
@@ -338,6 +338,10 @@ section,
   background: var(--panel);
 }
 
+.diagnostic-strip {
+  grid-template-columns: minmax(180px, 0.45fr) minmax(180px, 0.45fr) minmax(300px, 1.1fr);
+}
+
 .metric {
   position: relative;
   min-width: 0;
@@ -619,6 +623,13 @@ pre {
   font-weight: 700;
 }
 
+.diagnostic-help {
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
 .list {
   display: grid;
   gap: 0;
@@ -691,6 +702,9 @@ pre {
 .links-table {
   width: 100%;
   border-collapse: collapse;
+}
+
+.resource-table {
   table-layout: fixed;
 }
 
@@ -743,15 +757,15 @@ pre {
 }
 
 .links-table .rel-column {
-  width: 32%;
+  width: 30%;
 }
 
 .links-table .target-column {
-  width: 50%;
+  width: auto;
 }
 
 .links-table .type-column {
-  width: 18%;
+  width: 22em;
 }
 
 .target-kind {
@@ -794,6 +808,13 @@ pre {
   border-radius: 0;
   color: var(--muted);
   text-align: center;
+}
+
+.error-message {
+  justify-items: start;
+  text-align: left;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 @media (max-width: 900px) {

--- a/webfinger-viewer-worker/src/lookup/request.rs
+++ b/webfinger-viewer-worker/src/lookup/request.rs
@@ -81,7 +81,9 @@ impl LookupRequest {
         let target_url = if points_at_webfinger_endpoint(&resource) {
             webfinger_url(&resource, &rels, policy)?
         } else {
-            let _validated = resource.parse::<Resource>()?;
+            let _validated = resource
+                .parse::<Resource>()
+                .map_err(LookupError::InvalidResource)?;
             resource_url(&resource, &rels, policy)?
         };
         validate_target_url(&target_url)?;
@@ -142,7 +144,9 @@ fn webfinger_url(input: &str, rels: &[String], policy: &LookupPolicy) -> Result<
         .find_map(|(key, value)| (key == "resource").then(|| value.into_owned()))
         .ok_or(LookupError::MissingResource)?;
     validate_resource(&resource)?;
-    let _validated = resource.parse::<Resource>()?;
+    let _validated = resource
+        .parse::<Resource>()
+        .map_err(LookupError::InvalidResource)?;
 
     if !rels.is_empty() {
         url.set_query(None);
@@ -400,7 +404,7 @@ mod tests {
         let error =
             LookupRequest::new("alice".to_string(), Vec::new(), &production_policy()).unwrap_err();
 
-        assert!(matches!(error, LookupError::WebFinger(_)));
+        assert!(matches!(error, LookupError::InvalidResource(_)));
     }
 
     #[test]

--- a/webfinger-viewer-worker/src/lookup/result.rs
+++ b/webfinger-viewer-worker/src/lookup/result.rs
@@ -158,8 +158,10 @@ pub enum LookupError {
     Url(#[from] url::ParseError),
 
     /// The resource string failed `webfinger-rs` resource validation.
-    #[error(transparent)]
-    WebFinger(#[from] webfinger_rs::ResourceError),
+    #[error(
+        "resource must be an absolute URI such as `acct:alice@example.com`, or a full `https://example.com/.well-known/webfinger?resource=...` URL; validation error: {0}"
+    )]
+    InvalidResource(#[source] webfinger_rs::ResourceError),
 
     /// Cloudflare Worker request, response, or header handling failed.
     #[error(transparent)]

--- a/webfinger-viewer-worker/src/server.rs
+++ b/webfinger-viewer-worker/src/server.rs
@@ -90,7 +90,7 @@ async fn serve_lookup(request: Request) -> worker::Result<Response> {
         Ok(request) => request,
         Err(error) => {
             error!(%error, "webfinger lookup input error");
-            return html_fragment_response(&view::lookup_error(&error.to_string()));
+            return html_fragment_response(&view::lookup_error(&error, None));
         }
     };
 
@@ -99,7 +99,8 @@ async fn serve_lookup(request: Request) -> worker::Result<Response> {
         Err(error) => {
             log_lookup_error(&error);
             error!(%error, "webfinger lookup worker error");
-            return html_fragment_response(&view::lookup_error(&error.to_string()));
+            let target_url = request.target_url().as_str();
+            return html_fragment_response(&view::lookup_error(&error, Some(target_url)));
         }
     };
     html_fragment_response(&view::lookup_result(&result))

--- a/webfinger-viewer-worker/src/view.rs
+++ b/webfinger-viewer-worker/src/view.rs
@@ -15,7 +15,7 @@ mod summary;
 
 use askama::Template;
 
-use crate::lookup::LookupResult;
+use crate::lookup::{LookupError, LookupResult};
 use meta::MetaView;
 use state::StateView;
 use summary::{SummaryView, raw_body};
@@ -63,11 +63,14 @@ pub fn lookup_result(result: &LookupResult) -> String {
 
 /// Renders a failed lookup as a normal result fragment so htmx still swaps it into the page.
 ///
-/// Use this for viewer-level failures such as malformed resources or Worker fetch errors.
-/// Non-htmx or cross-site callers are rejected by `server` before this rendering path.
-pub fn lookup_error(message: &str) -> String {
+/// Use this for failures where no target HTTP response exists. The target-status slot stays visible
+/// because this is a debugger: "not requested" and "no response" are more useful than hiding the
+/// HTTP layer behind a generic error banner. Non-htmx or cross-site callers are rejected by
+/// `server` before this rendering path.
+pub fn lookup_error(error: &LookupError, target_url: Option<&str>) -> String {
     let state = StateView::bad("Failed");
-    let template = LookupErrorTemplate { state, message };
+    let diagnostic = ErrorDiagnosticView::from_lookup_error(error, target_url);
+    let template = LookupErrorTemplate { state, diagnostic };
     template.render().expect("lookup error template renders")
 }
 
@@ -109,8 +112,88 @@ struct LookupErrorTemplate<'a> {
     /// Header state swapped out-of-band by htmx.
     state: StateView<'a>,
 
-    /// Full viewer-level error shown in the result body.
-    message: &'a str,
+    /// Developer-focused explanation of why no target HTTP status was available.
+    diagnostic: ErrorDiagnosticView,
+}
+
+/// Diagnostic view for failures that happen before a target HTTP response exists.
+///
+/// Target `404`, `500`, and Cloudflare edge codes such as `522` are rendered by
+/// `LookupResultTemplate` because the Worker received an HTTP response. This view is reserved for
+/// viewer input, deployment policy, URL construction, and Worker transport failures where the most
+/// useful debugging fact is why no target status code could be displayed.
+struct ErrorDiagnosticView {
+    /// Short phase label shown in the metadata strip.
+    phase: &'static str,
+
+    /// Target status slot text, such as `Not requested` or `No response`.
+    target_status: &'static str,
+
+    /// Endpoint text shown in the metadata strip.
+    endpoint: String,
+
+    /// Body heading for the diagnostic section.
+    title: &'static str,
+
+    /// Full error text copied from the concrete lookup error.
+    message: String,
+
+    /// Extra context that helps a developer decide the next check.
+    help: &'static str,
+}
+
+impl ErrorDiagnosticView {
+    /// Builds a diagnostic from a concrete lookup error and optional target URL.
+    ///
+    /// The optional target URL is only available after the viewer has parsed enough input to build
+    /// a request. Keeping that distinction in the rendered output prevents "network" failures from
+    /// looking the same as syntax or RFC resource-validation failures.
+    fn from_lookup_error(error: &LookupError, target_url: Option<&str>) -> Self {
+        match error {
+            LookupError::Worker(_) => Self {
+                phase: "Worker fetch",
+                target_status: "No response",
+                endpoint: target_url
+                    .unwrap_or("Target request was not built")
+                    .to_string(),
+                title: "Fetch Error",
+                message: error.to_string(),
+                help: "The Worker attempted the endpoint but did not receive an HTTP response. Check local server availability, protocol, port, TLS, and Cloudflare Worker fetch restrictions.",
+            },
+            LookupError::OffOriginTarget { .. } => Self {
+                phase: "Deployment policy",
+                target_status: "Not requested",
+                endpoint: "Blocked before fetch".to_string(),
+                title: "Policy Error",
+                message: error.to_string(),
+                help: "This deployment is same-origin by default. Use the public site's own WebFinger resources here, or use local Wrangler with a full localhost WebFinger URL for local debugging.",
+            },
+            LookupError::Url(_)
+            | LookupError::UnsupportedScheme(_)
+            | LookupError::NotWebFingerUrl => Self {
+                phase: "URL parsing",
+                target_status: "Not requested",
+                endpoint: "Invalid WebFinger endpoint".to_string(),
+                title: "URL Error",
+                message: error.to_string(),
+                help: "Full endpoint input must be an absolute HTTP(S) URL whose path is exactly /.well-known/webfinger and whose query includes resource.",
+            },
+            LookupError::MissingResource
+            | LookupError::CannotInferHost
+            | LookupError::InvalidResource(_)
+            | LookupError::ResourceTooLong { .. }
+            | LookupError::TooManyRels { .. }
+            | LookupError::RelTooLong { .. }
+            | LookupError::TargetUrlTooLong { .. } => Self {
+                phase: "Input validation",
+                target_status: "Not requested",
+                endpoint: "Not built".to_string(),
+                title: "Input Error",
+                message: error.to_string(),
+                help: "Enter an absolute WebFinger resource, for example acct:alice@example.com, or paste the exact /.well-known/webfinger URL you want to inspect.",
+            },
+        }
+    }
 }
 
 #[cfg(test)]
@@ -119,12 +202,39 @@ mod tests {
 
     #[test]
     fn lookup_error_keeps_header_short_and_body_specific() {
-        let html = lookup_error("missing resource");
+        let html = lookup_error(&LookupError::MissingResource, None);
 
         assert!(html.contains(
             r#"<span id="state" class="state-text bad" hx-swap-oob="true">Failed</span>"#
         ));
-        assert!(html.contains("<h2>Lookup Error</h2>"));
+        assert!(html.contains("<h2>Input Error</h2>"));
+        assert!(html.contains("Input validation"));
+        assert!(html.contains("Target status"));
+        assert!(html.contains("Not built"));
         assert!(html.contains("missing resource"));
+    }
+
+    #[test]
+    fn invalid_resource_error_keeps_parser_reason_visible() {
+        let error = LookupError::InvalidResource(webfinger_rs::ResourceError::RelativeReference);
+        let html = lookup_error(&error, None);
+
+        assert!(html.contains("resource must be an absolute URI such as"));
+        assert!(html.contains("validation error: resource must be an absolute URI"));
+    }
+
+    #[test]
+    fn lookup_error_shows_target_url_for_worker_failures() {
+        let error =
+            LookupError::Worker(worker::Error::RustError("Network connection lost.".into()));
+        let html = lookup_error(
+            &error,
+            Some("http://localhost:8787/.well-known/webfinger?resource=acct%3Aalice%40localhost"),
+        );
+
+        assert!(html.contains("Worker fetch"));
+        assert!(html.contains("No response"));
+        assert!(html.contains("http://localhost:8787/.well-known/webfinger"));
+        assert!(html.contains("Network connection lost."));
     }
 }

--- a/webfinger-viewer-worker/src/view/meta.rs
+++ b/webfinger-viewer-worker/src/view/meta.rs
@@ -40,11 +40,7 @@ impl MetaView {
         let redirect_location = result.redirect_location.clone().unwrap_or_default();
         Self {
             status: result.status.to_string(),
-            status_class: if (200..300).contains(&result.status) {
-                "good"
-            } else {
-                "bad"
-            },
+            status_class: status_class(result.status),
             content_type: result
                 .content_type
                 .clone()
@@ -53,5 +49,31 @@ impl MetaView {
             has_redirect_location: !redirect_location.is_empty(),
             redirect_location,
         }
+    }
+}
+
+/// Returns the visual severity for a target HTTP status.
+///
+/// The viewer always shows the exact status code; this class only helps scan completed target
+/// responses. Redirects are warnings because the Worker intentionally does not follow them, while
+/// 4xx, 5xx, and Cloudflare edge responses remain explicit target errors.
+fn status_class(status: u16) -> &'static str {
+    match status {
+        200..=299 => "good",
+        300..=399 => "warn",
+        _ => "bad",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_class_marks_completed_response_ranges() {
+        assert_eq!(status_class(200), "good");
+        assert_eq!(status_class(302), "warn");
+        assert_eq!(status_class(404), "bad");
+        assert_eq!(status_class(522), "bad");
     }
 }

--- a/webfinger-viewer-worker/templates/lookup_error.html
+++ b/webfinger-viewer-worker/templates/lookup_error.html
@@ -2,29 +2,34 @@
    The endpoint is intentionally htmx-only; this fragment uses 200 so htmx swaps it. #}
 <span id="state" class="state-text {{ state.class_name }}" hx-swap-oob="true">{{ state.message }}</span>
 <div id="results" class="results">
-  <div class="status-strip" aria-live="polite">
+  <div class="status-strip diagnostic-strip" aria-live="polite">
     <div class="metric">
-      <span class="metric-title">Status</span>
+      <span class="metric-title">Phase</span>
       <span class="metric-value pill bad copyable">
-        Error<button class="copy-value" type="button" data-copy="Error" aria-label="Copy value">Copy</button>
+        {{ diagnostic.phase }}<button class="copy-value" type="button" data-copy="{{ diagnostic.phase }}" aria-label="Copy value">Copy</button>
       </span>
     </div>
     <div class="metric">
-      <span class="metric-title">Content type</span>
-      <span class="metric-value muted">-</span>
+      <span class="metric-title">Target status</span>
+      <span class="metric-value metric-code copyable">
+        {{ diagnostic.target_status }}<button class="copy-value" type="button" data-copy="{{ diagnostic.target_status }}" aria-label="Copy value">Copy</button>
+      </span>
     </div>
     <div class="metric">
       <span class="metric-title">Endpoint</span>
-      <span class="metric-value muted">-</span>
+      <span class="metric-value metric-code copyable">
+        {{ diagnostic.endpoint }}<button class="copy-value" type="button" data-copy="{{ diagnostic.endpoint }}" aria-label="Copy value">Copy</button>
+      </span>
     </div>
   </div>
   <div class="workspace">
     <section>
-      <div class="toolbar"><h2>Lookup Error</h2></div>
+      <div class="toolbar"><h2>{{ diagnostic.title }}</h2></div>
       <div class="list">
         <p class="empty error-message copyable">
-          {{ message }}<button class="copy-value" type="button" data-copy="{{ message }}" aria-label="Copy value">Copy</button>
+          {{ diagnostic.message }}<button class="copy-value" type="button" data-copy="{{ diagnostic.message }}" aria-label="Copy value">Copy</button>
         </p>
+        <p class="diagnostic-help">{{ diagnostic.help }}</p>
       </div>
     </section>
   </div>


### PR DESCRIPTION
## Summary

- distinguish target HTTP responses from viewer/Worker failures in the rendered result panel
- keep non-2xx target responses in the normal debugger path with the exact status code, content type, endpoint, and raw body
- show pre-response failures as diagnostic phases such as input validation, deployment policy, URL parsing, or Worker fetch
- preserve the underlying `webfinger-rs` resource validation reason alongside viewer guidance
- tune the diagnostic strip and link type column so status/error details remain readable

## Validation

- `cargo fmt --all --check`
- `cargo test -p webfinger-viewer-worker`
- browser check on `http://localhost:8792/webfinger` for malformed input, Worker fetch failure, target `404`, and target `200`
