### PR TITLE
Add viewer browser history support

### DIFF
--- a/webfinger-viewer-worker/assets/app.js
+++ b/webfinger-viewer-worker/assets/app.js
@@ -2,11 +2,13 @@
 //
 // htmx owns lookup submission and result swapping. Keep this file limited to behavior that is local
 // to the browser: theme persistence, path-prefix-aware API targeting, context-sensitive
-// placeholders, and clipboard buttons. Parsed JRD rendering and lookup lifecycle state belong to
-// Rust view models, Askama templates, and htmx attributes.
+// placeholders, and clipboard buttons. Parsed JRD rendering, lookup lifecycle state, and initial
+// form hydration belong to Rust view models, Askama templates, and htmx attributes.
 
 const form = document.querySelector("#lookup-form");
 const resourceInput = document.querySelector("#resource");
+const relInput = document.querySelector("#rels");
+const relPresetInputs = Array.from(document.querySelectorAll(".rel-preset input[name='rel']"));
 const themeSelect = document.querySelector("#theme");
 const themeStorageKey = "webfinger-viewer-theme";
 
@@ -30,8 +32,9 @@ applyTheme(localStorage.getItem(themeStorageKey) || "auto");
 // Computes the lookup endpoint below the current page path.
 //
 // This Worker is intended to mount at paths like `/webfinger`; hard-coding `/api/lookup` would
-// escape that mount. htmx reads this attribute when the form submits, so setting it once during page
-// initialization keeps the template free of deployment-specific path logic.
+// escape that mount. htmx reads `hx-post` when the form submits, so setting it once during page
+// initialization keeps the template free of deployment-specific path logic while preserving the
+// POST-only rule for outbound WebFinger fetches.
 function apiPath() {
   const base = window.location.pathname.replace(/\/$/, "");
   return `${base || ""}/api/lookup`;
@@ -50,6 +53,54 @@ function resourcePlaceholder() {
   return `acct:alice@${host}`;
 }
 
+// Returns URL search parameters for either an htmx event path or the current location.
+//
+// htmx history events provide `detail.path`, which is the path/query being saved or restored.
+// Prefer that over `location.search`: during POST submissions and history traversal, the address
+// bar can lag the snapshot that htmx is currently processing.
+function searchParamsForPath(path) {
+  return new URL(path || window.location.href, window.location.origin).searchParams;
+}
+
+// Applies a viewer URL query to the form without issuing a lookup.
+//
+// Server-side Askama rendering handles hard refreshes. This browser-side copy exists for htmx
+// history restores: htmx can restore cached results locally, but the restored form controls may
+// contain values typed for the next lookup because inputs store live state as properties.
+function hydrateFormFromPath(path) {
+  const params = searchParamsForPath(path);
+  resourceInput.value = params.get("resource") || "";
+
+  const rels = params.getAll("rel").flatMap((value) =>
+    value
+      .split(/[,\n]/)
+      .map((rel) => rel.trim())
+      .filter(Boolean),
+  );
+  const selectedRels = new Set(rels);
+  const presetValues = new Set(relPresetInputs.map((input) => input.value));
+
+  for (const input of relPresetInputs) {
+    input.checked = selectedRels.has(input.value);
+  }
+  relInput.value = rels.filter((rel) => !presetValues.has(rel)).join(", ");
+}
+
+// Applies the current viewer URL query to the form without issuing a lookup.
+function hydrateFormFromLocation() {
+  hydrateFormFromPath(window.location.href);
+}
+
+// Rehydrates after browser history traversal.
+//
+// The zero-delay pass handles ordinary browser restoration. The second pass handles htmx snapshot
+// restoration that settles just after the history event; both passes are idempotent and never fetch.
+function hydrateFormAfterHistoryRestore(event) {
+  const path = event?.detail?.path || window.location.href;
+  window.setTimeout(() => hydrateFormFromPath(path), 0);
+  window.setTimeout(() => hydrateFormFromPath(path), 50);
+}
+
 // Copies a value when the Clipboard API is available.
 //
 // Missing text is a no-op because some controls copy optional output that is absent before the
@@ -61,10 +112,40 @@ async function copy(text) {
   }
 }
 
-form.setAttribute("hx-get", apiPath());
+// Persists the URL-represented form state into attributes before htmx snapshots history.
+//
+// htmx snapshots mutable form controls into its history cache. Use `detail.path`, not live input
+// properties, so each cached form reflects the URL htmx is saving even when the user has already
+// typed the next POST body.
+function syncFormStateForHistory(event) {
+  const params = searchParamsForPath(event?.detail?.path);
+  resourceInput.setAttribute("value", params.get("resource") || "");
+
+  const rels = params.getAll("rel").flatMap((value) =>
+    value
+      .split(/[,\n]/)
+      .map((rel) => rel.trim())
+      .filter(Boolean),
+  );
+  const selectedRels = new Set(rels);
+  const presetValues = new Set(relPresetInputs.map((input) => input.value));
+  relInput.setAttribute("value", rels.filter((rel) => !presetValues.has(rel)).join(", "));
+  for (const input of relPresetInputs) {
+    if (selectedRels.has(input.value)) {
+      input.setAttribute("checked", "");
+    } else {
+      input.removeAttribute("checked");
+    }
+  }
+}
+
+form.setAttribute("hx-post", apiPath());
 resourceInput.setAttribute("placeholder", resourcePlaceholder());
 
 themeSelect.addEventListener("change", () => applyTheme(themeSelect.value));
+document.body.addEventListener("htmx:beforeHistorySave", syncFormStateForHistory);
+document.body.addEventListener("htmx:historyRestore", hydrateFormAfterHistoryRestore);
+window.addEventListener("popstate", hydrateFormAfterHistoryRestore);
 
 // Use delegated copy handling because htmx replaces the result fragment after every lookup.
 //

--- a/webfinger-viewer-worker/src/lookup/request.rs
+++ b/webfinger-viewer-worker/src/lookup/request.rs
@@ -35,31 +35,19 @@ pub struct LookupRequest {
 }
 
 impl LookupRequest {
-    /// Builds a lookup request from the viewer API query string.
+    /// Builds a lookup request from browser form values.
     ///
-    /// Empty `rel` query parameters are ignored because the browser UI may send optional text-box
-    /// state. Unknown query parameters are ignored so deployment platforms can add their own
-    /// routing metadata without breaking lookups. Resource, relation, and target URL sizes are
-    /// bounded before any outbound fetch so the Worker cannot be used to render or request
-    /// unbounded user input.
-    pub fn from_url_query(url: &Url, policy: &LookupPolicy) -> Result<Self, LookupError> {
-        let mut resource = None;
-        let mut rels = Vec::new();
-        for (key, value) in url.query_pairs() {
-            match key.as_ref() {
-                "resource" => resource = Some(value.into_owned()),
-                "rel" => {
-                    for rel in value.split([',', '\n']).map(str::trim) {
-                        if !rel.is_empty() {
-                            rels.push(rel.to_string());
-                        }
-                    }
-                }
-                _ => {}
-            }
-        }
-
+    /// The free-form relation text box may send comma/newline-separated values, while preset
+    /// checkboxes send repeated `rel` fields. Resource, relation, and target URL sizes are bounded
+    /// before any outbound fetch so the Worker cannot be used to render or request unbounded user
+    /// input.
+    pub fn from_form_values(
+        resource: Option<String>,
+        rel_values: Vec<String>,
+        policy: &LookupPolicy,
+    ) -> Result<Self, LookupError> {
         let resource = resource.ok_or(LookupError::MissingResource)?;
+        let rels = split_rel_values(rel_values);
         Self::new(resource, rels, policy)
     }
 
@@ -110,6 +98,24 @@ impl LookupRequest {
     pub fn target_url(&self) -> &Url {
         &self.target_url
     }
+}
+
+/// Normalizes raw relation form values into target `rel` query parameters.
+///
+/// Keeping this splitter near request construction ensures URL-query tests, POST form handling, and
+/// history URL construction can validate against the same accepted input shape.
+fn split_rel_values(rel_values: Vec<String>) -> Vec<String> {
+    rel_values
+        .into_iter()
+        .flat_map(|value| {
+            value
+                .split([',', '\n'])
+                .map(str::trim)
+                .filter(|rel| !rel.is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .collect()
 }
 
 /// Returns true when the user supplied the WebFinger endpoint itself.

--- a/webfinger-viewer-worker/src/server.rs
+++ b/webfinger-viewer-worker/src/server.rs
@@ -5,16 +5,17 @@
 //! target URLs are derived or how JRD fields are displayed; those belong to `lookup` and `view` so
 //! protocol behavior and rendering can be changed without reading response-header plumbing.
 //!
-//! `/api/lookup` is not a general JSON API. It is a same-page htmx endpoint for the bundled form:
-//! callers must send `HX-Request`, and obvious cross-site browser requests are rejected using Fetch
-//! Metadata. This is not authentication, but it avoids advertising the Worker as a public
+//! `/api/lookup` is not a general JSON API. It is a same-page htmx POST endpoint for the bundled
+//! form: callers must send `HX-Request`, and obvious cross-site browser requests are rejected using
+//! Fetch Metadata. This is not authentication, but it avoids advertising the Worker as a public
 //! server-side lookup API and prevents normal cross-origin browser reads because no CORS headers are
 //! emitted. Malformed viewer input and Worker-fetch failures still render HTML fragments with
 //! status `200` so htmx swaps them into `#results`. Target WebFinger status is displayed inside the
 //! fragment rather than encoded as the Worker response status.
 
-use ::worker::{Context, Env, Method, Request, Response};
+use ::worker::{Context, Env, FormEntry, Method, Request, Response};
 use tracing::{error, info};
+use url::{Url, form_urlencoded};
 
 use crate::lookup::{LookupPolicy, LookupRequest, fetch_webfinger, log_lookup_error};
 use crate::view;
@@ -53,7 +54,7 @@ pub async fn serve(request: Request, _env: Env, _ctx: Context) -> worker::Result
 
     if method == Method::Get || method == Method::Head {
         log_viewer_request(&method, url.path(), "page");
-        return html_response(&view::page());
+        return html_response(&view::page(&url));
     }
 
     log_viewer_request(&method, url.path(), "method_not_allowed");
@@ -67,7 +68,7 @@ pub async fn serve(request: Request, _env: Env, _ctx: Context) -> worker::Result
 /// actual Worker request, not a parallel set of derived arguments. The order of checks is also the
 /// endpoint policy: reject unsupported callers first, then reject cross-site browser traffic, then
 /// parse viewer input only for the supported same-page htmx path.
-async fn serve_lookup(request: Request) -> worker::Result<Response> {
+async fn serve_lookup(mut request: Request) -> worker::Result<Response> {
     let method = request.method();
     let url = request.url()?;
 
@@ -80,17 +81,22 @@ async fn serve_lookup(request: Request) -> worker::Result<Response> {
         return text_response("forbidden", 403);
     }
 
-    if method != Method::Get {
+    if method != Method::Post {
         log_viewer_request(&method, url.path(), "lookup_method_not_allowed");
         return text_response("method not allowed", 405);
     }
 
+    let form = LookupForm::from_request(&mut request).await?;
+    let history_url = viewer_history_url(&url, &form);
     let policy = LookupPolicy::from_viewer_url(&url);
-    let request = match LookupRequest::from_url_query(&url, &policy) {
+    let lookup_request =
+        LookupRequest::from_form_values(form.resource.clone(), form.rels.clone(), &policy);
+    let request = match lookup_request {
         Ok(request) => request,
         Err(error) => {
             error!(%error, "webfinger lookup input error");
-            return html_fragment_response(&view::lookup_error(&error, None));
+            let html = view::lookup_error(&error, None);
+            return html_fragment_response(&html, Some(&history_url));
         }
     };
 
@@ -100,10 +106,11 @@ async fn serve_lookup(request: Request) -> worker::Result<Response> {
             log_lookup_error(&error);
             error!(%error, "webfinger lookup worker error");
             let target_url = request.target_url().as_str();
-            return html_fragment_response(&view::lookup_error(&error, Some(target_url)));
+            let html = view::lookup_error(&error, Some(target_url));
+            return html_fragment_response(&html, Some(&history_url));
         }
     };
-    html_fragment_response(&view::lookup_result(&result))
+    html_fragment_response(&view::lookup_result(&result), Some(&history_url))
 }
 
 /// Returns the full viewer page shell.
@@ -144,17 +151,96 @@ fn text_response(body: &str, status: u16) -> worker::Result<Response> {
 /// htmx fragments use `200` for viewer-level errors so the browser swaps the failure UI normally.
 /// Target endpoint failures should be represented inside the fragment so the user can inspect the
 /// target status, headers, and body as the debugging result.
-fn html_fragment_response(html: &str) -> worker::Result<Response> {
-    let response = Response::builder()
+fn html_fragment_response(html: &str, history_url: Option<&str>) -> worker::Result<Response> {
+    let mut builder = Response::builder()
         .with_status(200)
         .with_header("content-type", "text/html; charset=utf-8")?
         .with_header("cache-control", "no-store")?
         .with_header("content-security-policy", CONTENT_SECURITY_POLICY)?
         .with_header("x-content-type-options", "nosniff")?
         .with_header("referrer-policy", "no-referrer")?
-        .with_header("permissions-policy", "clipboard-write=(self)")?
-        .fixed(html.as_bytes().to_vec());
+        .with_header("permissions-policy", "clipboard-write=(self)")?;
+    if let Some(history_url) = history_url {
+        builder = builder.with_header("hx-push-url", history_url)?;
+    }
+    let response = builder.fixed(html.as_bytes().to_vec());
     Ok(response)
+}
+
+/// Returns the viewer URL that represents a lookup in browser history.
+///
+/// htmx submits to `/api/lookup`, but browser history should stay on the user-facing viewer path
+/// such as `/webfinger?resource=acct%3Aalice%40example.com`. The query is rebuilt from supported
+/// form fields so empty optional `rel` controls and unrelated routing parameters do not pollute
+/// shareable URLs.
+fn viewer_history_url(lookup_url: &Url, form: &LookupForm) -> String {
+    let viewer_path = lookup_url
+        .path()
+        .strip_suffix(API_PATH)
+        .filter(|path| !path.is_empty())
+        .unwrap_or("/");
+    let query = viewer_history_query(form);
+    if query.is_empty() {
+        viewer_path.to_string()
+    } else {
+        format!("{viewer_path}?{query}")
+    }
+}
+
+/// Builds the canonical viewer query string from submitted form values.
+///
+/// Relation filters are accepted either as repeated `rel` parameters or comma/newline-separated
+/// text box values. Splitting them here makes the address bar match the POST body that
+/// `LookupRequest` sends to the target endpoint.
+fn viewer_history_query(form: &LookupForm) -> String {
+    let mut query = form_urlencoded::Serializer::new(String::new());
+    if let Some(resource) = form.resource.as_deref().filter(|value| !value.is_empty()) {
+        query.append_pair("resource", resource);
+    }
+    for value in &form.rels {
+        for rel in value.split([',', '\n']).map(str::trim) {
+            if !rel.is_empty() {
+                query.append_pair("rel", rel);
+            }
+        }
+    }
+    query.finish()
+}
+
+/// Raw lookup fields submitted by the htmx form.
+///
+/// The POST body is the only input that can trigger an outbound WebFinger fetch. These same fields
+/// also produce the pushed viewer URL, keeping history and shareable URLs as form state without
+/// making a plain GET page load perform network I/O against a target server.
+struct LookupForm {
+    /// Resource string from the required form field.
+    resource: Option<String>,
+
+    /// Raw relation values from the optional text box and preset checkboxes.
+    rels: Vec<String>,
+}
+
+impl LookupForm {
+    /// Reads the htmx form body from the Worker request.
+    ///
+    /// `Request::form_data` handles the browser's `application/x-www-form-urlencoded` submission.
+    /// File values are ignored because the viewer form has no file controls; treating them as
+    /// absent keeps malformed programmatic posts on the normal validation path.
+    async fn from_request(request: &mut Request) -> worker::Result<Self> {
+        let form = request.form_data().await?;
+        let resource = form.get_field("resource");
+        let rels = form
+            .get_all("rel")
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|entry| match entry {
+                FormEntry::Field(value) => Some(value),
+                FormEntry::File(_) => None,
+            })
+            .collect();
+
+        Ok(Self { resource, rels })
+    }
 }
 
 /// Returns true when the request came from htmx.
@@ -186,4 +272,48 @@ fn is_cross_site_request(request: &Request) -> worker::Result<bool> {
 /// exposing headers or other browser metadata.
 fn log_viewer_request(method: &Method, path: &str, outcome: &str) {
     info!(method = ?method, path, outcome, "webfinger viewer request");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn history_url_uses_viewer_path_not_api_path() {
+        let url = Url::parse("https://example.com/webfinger/api/lookup").unwrap();
+        let form = LookupForm {
+            resource: Some("acct:alice@example.com".to_string()),
+            rels: vec!["self".to_string()],
+        };
+
+        assert_eq!(
+            viewer_history_url(&url, &form),
+            "/webfinger?resource=acct%3Aalice%40example.com&rel=self"
+        );
+    }
+
+    #[test]
+    fn history_url_splits_and_omits_empty_relation_filters() {
+        let url = Url::parse("https://example.com/webfinger/api/lookup").unwrap();
+        let form = LookupForm {
+            resource: Some("acct:alice@example.com".to_string()),
+            rels: vec!["".to_string(), "self, issuer".to_string()],
+        };
+
+        assert_eq!(
+            viewer_history_url(&url, &form),
+            "/webfinger?resource=acct%3Aalice%40example.com&rel=self&rel=issuer"
+        );
+    }
+
+    #[test]
+    fn history_url_without_form_values_keeps_viewer_path() {
+        let url = Url::parse("https://example.com/webfinger/api/lookup").unwrap();
+        let form = LookupForm {
+            resource: None,
+            rels: Vec::new(),
+        };
+
+        assert_eq!(viewer_history_url(&url, &form), "/webfinger");
+    }
 }

--- a/webfinger-viewer-worker/src/view.rs
+++ b/webfinger-viewer-worker/src/view.rs
@@ -14,6 +14,7 @@ mod state;
 mod summary;
 
 use askama::Template;
+use url::Url;
 
 use crate::lookup::{LookupError, LookupResult};
 use meta::MetaView;
@@ -32,11 +33,13 @@ const APP_JS: &str = include_str!("../assets/app.js");
 /// CSS, htmx, and the small local behavior script are separate source files but are embedded into
 /// the Worker response. That keeps deployment simple for a path-mounted Worker while avoiding a
 /// monolithic HTML source file.
-pub fn page() -> String {
+pub fn page(url: &Url) -> String {
+    let form = PageFormView::from_url(url);
     let page = PageTemplate {
         htmx_js: HTMX_JS,
         app_css: APP_CSS,
         app_js: APP_JS,
+        form,
     };
     page.render().expect("page template renders")
 }
@@ -85,6 +88,71 @@ struct PageTemplate {
 
     /// Small browser behavior script embedded into the page.
     app_js: &'static str,
+
+    /// Initial form values derived from the viewer URL query.
+    form: PageFormView,
+}
+
+/// Initial values for the lookup form in the full page shell.
+///
+/// Direct loads of `/webfinger?resource=...&rel=...` should make the form reflect the URL without
+/// running a lookup. User-triggered htmx submissions then own fetching and history pushes.
+struct PageFormView {
+    /// Initial resource text field value.
+    resource: String,
+
+    /// Custom relation values shown in the free-form text box.
+    rels: String,
+
+    /// True when the `self` preset should be checked.
+    self_checked: bool,
+
+    /// True when the profile-page preset should be checked.
+    profile_checked: bool,
+
+    /// True when the OpenID issuer preset should be checked.
+    issuer_checked: bool,
+}
+
+impl PageFormView {
+    /// Builds initial form values from a viewer URL.
+    ///
+    /// The relation parser mirrors the lookup parser's permissive input shape: repeated `rel`
+    /// parameters and comma/newline-separated text values are both accepted. Known presets become
+    /// checked boxes; everything else stays in the custom rel text box.
+    fn from_url(url: &Url) -> Self {
+        let resource = url
+            .query_pairs()
+            .find_map(|(key, value)| (key == "resource").then(|| value.into_owned()))
+            .unwrap_or_default();
+
+        let mut self_checked = false;
+        let mut profile_checked = false;
+        let mut issuer_checked = false;
+        let mut custom_rels = Vec::new();
+        for (key, value) in url.query_pairs() {
+            if key != "rel" {
+                continue;
+            }
+            for rel in value.split([',', '\n']).map(str::trim) {
+                match rel {
+                    "" => {}
+                    "self" => self_checked = true,
+                    "http://webfinger.net/rel/profile-page" => profile_checked = true,
+                    "http://openid.net/specs/connect/1.0/issuer" => issuer_checked = true,
+                    custom => custom_rels.push(custom.to_string()),
+                }
+            }
+        }
+
+        Self {
+            resource,
+            rels: custom_rels.join(", "),
+            self_checked,
+            profile_checked,
+            issuer_checked,
+        }
+    }
 }
 
 #[derive(Template)]
@@ -199,6 +267,20 @@ impl ErrorDiagnosticView {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn page_hydrates_form_from_viewer_url_without_results() {
+        let url = Url::parse(
+            "https://example.com/webfinger?resource=acct%3Aalice%40example.com&rel=self&rel=https%3A%2F%2Fexample.com%2Frel%2Fcustom",
+        )
+        .unwrap();
+        let html = page(&url);
+
+        assert!(html.contains(r#"value="acct:alice@example.com""#));
+        assert!(html.contains(r#"value="https://example.com/rel/custom""#));
+        assert!(html.contains(r#"value="self" checked"#));
+        assert!(html.contains(r#"<div id="results" class="results" hidden></div>"#));
+    }
 
     #[test]
     fn lookup_error_keeps_header_short_and_body_specific() {

--- a/webfinger-viewer-worker/templates/page.html
+++ b/webfinger-viewer-worker/templates/page.html
@@ -11,7 +11,7 @@
   <style>{{ app_css|safe }}</style>
 </head>
 <body>
-  <main>
+  <main hx-history-elt>
     <header class="app-header">
       <div class="brand">
         <h1>WebFinger Viewer</h1>
@@ -34,18 +34,19 @@
       <div class="query-panel">
         <form
           id="lookup-form"
-          hx-get="api/lookup"
+          hx-post="api/lookup"
           hx-indicator="#state-loading"
           hx-target="#results"
           hx-swap="outerHTML"
         >
-          {# app.js rewrites hx-get at runtime so the request lands below the current path prefix. #}
+          {# app.js rewrites hx-post at runtime so the request lands below the current path prefix. #}
           <label>
             <span>Resource or WebFinger URL</span>
             <input
               id="resource"
               name="resource"
               required
+              value="{{ form.resource }}"
               placeholder="acct:alice@example.com"
               spellcheck="false"
               autocomplete="off"
@@ -57,6 +58,7 @@
               <input
                 id="rels"
                 name="rel"
+                value="{{ form.rels }}"
                 placeholder="Optional: self, profile-page, issuer, or a rel URI"
                 spellcheck="false"
                 autocomplete="off"
@@ -64,15 +66,15 @@
             </label>
             <div class="rel-presets" aria-label="Relation presets">
               <label class="rel-preset">
-                <input type="checkbox" name="rel" value="self">
+                <input type="checkbox" name="rel" value="self"{% if form.self_checked %} checked{% endif %}>
                 self
               </label>
               <label class="rel-preset">
-                <input type="checkbox" name="rel" value="http://webfinger.net/rel/profile-page">
+                <input type="checkbox" name="rel" value="http://webfinger.net/rel/profile-page"{% if form.profile_checked %} checked{% endif %}>
                 profile
               </label>
               <label class="rel-preset">
-                <input type="checkbox" name="rel" value="http://openid.net/specs/connect/1.0/issuer">
+                <input type="checkbox" name="rel" value="http://openid.net/specs/connect/1.0/issuer"{% if form.issuer_checked %} checked{% endif %}>
                 issuer
               </label>
             </div>


### PR DESCRIPTION
## Summary

- make WebFinger target fetches POST-only from the htmx form
- keep pushed `/webfinger?resource=...&rel=...` URLs as viewer state without triggering fetches on direct GET loads
- hydrate direct loads and htmx history restores so Back/Forward keeps the URL, form, result, and target status aligned

## Validation

- `cargo fmt --all --check`
- `cargo test -p webfinger-viewer-worker`
- `cargo check -p webfinger-viewer-worker --target wasm32-unknown-unknown`
- `npm run deploy:dry-run`
- browser-verified plain GET hydrates the form with hidden results and `Idle` state
- browser-verified htmx submissions use `POST /webfinger/api/lookup`, push clean viewer URLs, and restore 200/404 results correctly through Back/Forward
- `curl -i -H 'HX-Request: true' http://localhost:8792/webfinger/api/lookup?resource=acct%3Ajoshka%40hachyderm.io` returns `405 Method Not Allowed`
