### PR TITLE
test: improve code coverage

### DIFF
--- a/webfinger-cli/src/main.rs
+++ b/webfinger-cli/src/main.rs
@@ -19,7 +19,7 @@ struct Cli {
     verbosity: Verbosity<InfoLevel>,
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Args, PartialEq, Eq)]
 #[command(next_line_help = false)]
 struct FetchCommand {
     /// The resource to fetch
@@ -113,7 +113,6 @@ impl FetchCommand {
 mod tests {
     use super::*;
 
-    /// Builds a fetch command with only the resource set.
     fn command(resource: &str) -> FetchCommand {
         FetchCommand {
             resource: resource.to_string(),
@@ -153,6 +152,142 @@ mod tests {
         let host = command.host(&resource).unwrap();
 
         assert_eq!(host, "example.org");
+    }
+
+    /// Honors an explicit CLI host over any host that could be inferred from the resource.
+    ///
+    /// WebFinger deployments can serve an account domain from a different endpoint host, so the
+    /// caller-provided host must remain authoritative when present.
+    #[test]
+    fn host_uses_explicit_host() {
+        let mut command = command("acct:carol@example.org");
+        command.host = Some("webfinger.example.net".to_string());
+        let resource = command.resource().unwrap();
+
+        let host = command.host(&resource).unwrap();
+
+        assert_eq!(host, "webfinger.example.net");
+    }
+
+    /// Rejects host inference when neither an HTTP(S) authority nor an `acct:` authority is
+    /// available.
+    ///
+    /// RFC 7033 section 4.1 requires a concrete WebFinger endpoint host for the outgoing query.
+    /// Without an explicit CLI host, only hierarchical resource URIs and `acct:` account addresses
+    /// provide enough information to infer that endpoint.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.1>.
+    /// See <https://www.rfc-editor.org/rfc/rfc7565.html#section-3>.
+    #[test]
+    fn host_rejects_resource_without_inferable_host() {
+        let command = command("mailto:carol");
+        let resource = command.resource().unwrap();
+
+        let error = command.host(&resource).expect_err("missing host");
+
+        assert_eq!(error.to_string(), "no host provided");
+    }
+
+    /// Parses all relation filters through the same validated `Rel` boundary used by the library.
+    ///
+    /// Repeated `--rel` options become repeated WebFinger `rel` query parameters, so their order is
+    /// observable in the generated request URI.
+    #[test]
+    fn link_relations_parse_in_order() {
+        let mut command = command("acct:carol@example.org");
+        command.rel = vec![
+            "http://webfinger.net/rel/profile-page".to_string(),
+            "avatar".to_string(),
+        ];
+
+        let rels = command.link_relations().unwrap();
+
+        assert_eq!(
+            rels.iter().map(Rel::as_ref).collect::<Vec<_>>(),
+            ["http://webfinger.net/rel/profile-page", "avatar"]
+        );
+    }
+
+    /// Rejects invalid CLI relation filters before a network request can be built.
+    ///
+    /// This keeps CLI validation consistent with response and request relation validation instead
+    /// of letting malformed relation strings reach the transport layer.
+    #[test]
+    fn link_relations_reject_invalid_rel() {
+        let mut command = command("acct:carol@example.org");
+        command.rel = vec!["profile page".to_string()];
+
+        let error = command.link_relations().expect_err("invalid rel");
+
+        assert!(error.to_string().contains("invalid relation type"));
+    }
+
+    /// Stops invalid resource text before the CLI constructs a WebFinger request.
+    ///
+    /// The command path should fail with local validation context, not with a later Reqwest URL or
+    /// transport error that hides the malformed resource.
+    #[tokio::test]
+    async fn execute_rejects_invalid_resource_before_network() {
+        let command = command("http:foo");
+
+        let error = command.execute().await.expect_err("invalid resource");
+
+        assert!(error.to_string().contains("invalid resource"));
+    }
+
+    /// Stops execution when the endpoint host cannot be explicit or inferred.
+    ///
+    /// This covers the full async command path for the same missing-host boundary tested directly
+    /// by `host_rejects_resource_without_inferable_host`.
+    #[tokio::test]
+    async fn execute_rejects_missing_host_before_network() {
+        let command = command("mailto:carol");
+
+        let error = command.execute().await.expect_err("missing host");
+
+        assert_eq!(error.to_string(), "no host provided");
+    }
+
+    /// Validates relation filters before initializing the HTTP client.
+    ///
+    /// A bad `--rel` value should be reported as command input failure even when the resource and
+    /// host are otherwise usable.
+    #[tokio::test]
+    async fn execute_rejects_invalid_relation_before_network() {
+        let mut command = command("acct:carol@example.org");
+        command.host = Some("example.org".to_string());
+        command.rel = vec!["profile page".to_string()];
+
+        let error = command.execute().await.expect_err("invalid rel");
+
+        assert!(error.to_string().contains("invalid relation type"));
+    }
+
+    /// Locks the positional CLI shape for resource, optional host, repeated rels, and TLS override.
+    ///
+    /// Clap derives this parser from struct field order and attributes, so a small parser refactor
+    /// can unintentionally change the public command line.
+    #[test]
+    fn cli_parses_resource_host_rel_and_insecure_flag() {
+        let cli = Cli::try_parse_from([
+            "webfinger",
+            "acct:carol@example.org",
+            "example.org",
+            "--rel",
+            "avatar",
+            "--insecure",
+        ])
+        .unwrap();
+
+        assert_eq!(
+            cli.fetch_command,
+            FetchCommand {
+                resource: "acct:carol@example.org".to_string(),
+                host: Some("example.org".to_string()),
+                rel: vec!["avatar".to_string()],
+                insecure: true,
+            }
+        );
     }
 
     /// Rejects non-hierarchical HTTP resource text before host inference.

--- a/webfinger-rs/src/axum.rs
+++ b/webfinger-rs/src/axum.rs
@@ -136,18 +136,22 @@ impl IntoResponse for WebFingerResponse {
 /// - [`Rejection::InvalidQueryString`] when the query string is missing `resource`, contains more
 ///   than one `resource`, or contains malformed percent encoding;
 /// - [`Rejection::InvalidResource`] when the `resource` value is not an absolute URI.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Rejection {
     /// The WebFinger query string is missing required data or is malformed.
+    #[error("{0}")]
     InvalidQueryString(String),
 
     /// The `resource` query parameter is not an absolute URI.
-    InvalidResource(ResourceError),
+    #[error("invalid resource: {0}")]
+    InvalidResource(#[source] ResourceError),
 
     /// The `Host` header is missing.
+    #[error("missing host")]
     MissingHost,
 
     /// A `rel` query parameter is invalid.
+    #[error(transparent)]
     InvalidRel(crate::Error),
 }
 
@@ -251,6 +255,8 @@ impl<S: Send + Sync> FromRequestParts<S> for WebFingerRequest {
 
 #[cfg(test)]
 mod tests {
+    use std::error::Error;
+
     use axum::body::Body;
     use axum::routing::get;
     use http::{Method, Request, Response};
@@ -261,6 +267,35 @@ mod tests {
     use crate::WELL_KNOWN_PATH;
 
     type Result<T = (), E = Box<dyn std::error::Error>> = std::result::Result<T, E>;
+
+    fn assert_error_traits<T>()
+    where
+        T: std::fmt::Debug + std::fmt::Display + std::error::Error + Send + Sync + 'static,
+    {
+    }
+
+    /// Keeps Axum extraction failures usable as ordinary application errors.
+    ///
+    /// `Rejection` is public, so callers should be able to log it, display it, and inspect sources
+    /// without first converting it into an HTTP response.
+    #[test]
+    fn rejection_implements_error_traits() {
+        assert_error_traits::<Rejection>();
+    }
+
+    /// Preserves the underlying resource parse error for diagnostics.
+    ///
+    /// Axum renders a flat `400 Bad Request`, but applications that handle `Rejection` directly
+    /// should still be able to distinguish a relative resource from other query failures.
+    #[test]
+    fn invalid_resource_rejection_exposes_source_error() {
+        let rejection = Rejection::InvalidResource(ResourceError::RelativeReference);
+
+        assert_eq!(
+            rejection.source().map(ToString::to_string),
+            Some("resource must be an absolute URI".to_string())
+        );
+    }
 
     /// A small helper trait to convert a response body into a string.
     trait IntoText {

--- a/webfinger-rs/src/http.rs
+++ b/webfinger-rs/src/http.rs
@@ -153,4 +153,28 @@ mod tests {
             "https://example.org/.well-known/webfinger?resource=acct%3Acarol%40example.org&rel=https%3A%2F%2Fexample.org%2Frel%2Fa%252Fb",
         );
     }
+
+    /// Builds protocol response headers for JRD JSON and cross-origin WebFinger reads.
+    ///
+    /// RFC 7033 section 10.2 registers `application/jrd+json` for WebFinger responses, and
+    /// section 5 recommends `Access-Control-Allow-Origin: *` so browser clients can read public
+    /// WebFinger data.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-5>.
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-10.2>.
+    #[test]
+    fn response_conversion_sets_jrd_and_cors_headers() {
+        let response = WebFingerResponse::new("acct:carol@example.org");
+
+        let response = http::Response::try_from(&response).unwrap();
+
+        assert_eq!(
+            response.headers().get("Content-Type"),
+            Some(&http::HeaderValue::from_static("application/jrd+json")),
+        );
+        assert_eq!(
+            response.headers().get("Access-Control-Allow-Origin"),
+            Some(&http::HeaderValue::from_static("*")),
+        );
+    }
 }

--- a/webfinger-rs/src/query.rs
+++ b/webfinger-rs/src/query.rs
@@ -103,7 +103,7 @@ fn validate_percent_escapes(value: &str) -> Result<(), RequestParamsError> {
 }
 
 /// Errors that can occur while parsing WebFinger query parameters.
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq, Eq)]
 pub(crate) enum RequestParamsError {
     /// The required `resource` parameter is missing.
     #[error("missing resource parameter")]
@@ -119,18 +119,13 @@ pub(crate) enum RequestParamsError {
 
     /// The required `resource` parameter is not an absolute URI.
     #[error("invalid resource: {0}")]
-    InvalidResource(ResourceError),
-}
-
-impl From<ResourceError> for RequestParamsError {
-    fn from(error: ResourceError) -> Self {
-        Self::InvalidResource(error)
-    }
+    InvalidResource(#[from] ResourceError),
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::error::Error;
 
     /// Decodes a percent-encoded `acct:` resource.
     ///
@@ -208,10 +203,7 @@ mod tests {
         const QUERY: &str = "resource=acct%3Acarol%40example.org&rel=%FF";
         let error = QUERY.parse::<RequestParams>().unwrap_err();
 
-        assert!(
-            matches!(error, RequestParamsError::InvalidPercentEncoding),
-            "expected invalid-percent-encoding error, got {error:?}",
-        );
+        assert_eq!(error, RequestParamsError::InvalidPercentEncoding);
     }
 
     /// Rejects malformed percent escape syntax.
@@ -226,10 +218,27 @@ mod tests {
         const QUERY: &str = "resource=acct%3Acarol%40example.org&rel=%GG";
         let error = QUERY.parse::<RequestParams>().unwrap_err();
 
-        assert!(
-            matches!(error, RequestParamsError::InvalidPercentEncoding),
-            "expected invalid-percent-encoding error, got {error:?}",
-        );
+        assert_eq!(error, RequestParamsError::InvalidPercentEncoding);
+    }
+
+    /// Rejects incomplete escapes in parameter keys and values.
+    ///
+    /// Query keys still use RFC 3986 percent encoding. A malformed key cannot be safely ignored
+    /// because it may be a misspelled or corrupted `resource` parameter.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1>.
+    #[test]
+    fn rejects_incomplete_percent_escape_syntax() {
+        for query in [
+            "resource%=acct%3Acarol%40example.org",
+            "resource%4=acct%3Acarol%40example.org",
+            "resource=acct%3Acarol%40example.org%",
+            "resource=acct%3Acarol%40example.org%4",
+        ] {
+            let error = query.parse::<RequestParams>().unwrap_err();
+
+            assert_eq!(error, RequestParamsError::InvalidPercentEncoding);
+        }
     }
 
     /// Accepts `resource` in any query parameter position.
@@ -249,6 +258,27 @@ mod tests {
             RequestParams {
                 resource: "acct:carol@example.org".parse().unwrap(),
                 rel: vec!["profile".to_string()],
+            },
+        );
+    }
+
+    /// Ignores unknown query parameters while preserving the required WebFinger fields.
+    ///
+    /// RFC 7033 defines `resource` and `rel`; ignoring additional parameters keeps adapters
+    /// forwards-compatible without letting extensions alter the parsed request target.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.1>.
+    #[test]
+    fn ignores_unknown_query_params() {
+        let query: RequestParams = "resource=acct%3Acarol%40example.org&foo=bar&rel=avatar"
+            .parse()
+            .unwrap();
+
+        assert_eq!(
+            query,
+            RequestParams {
+                resource: "acct:carol@example.org".parse().unwrap(),
+                rel: vec!["avatar".to_string()],
             },
         );
     }
@@ -327,10 +357,7 @@ mod tests {
             "resource=acct%3Acarol%40example.org&resource=acct%3Aalice%40example.org";
         let error = QUERY.parse::<RequestParams>().unwrap_err();
 
-        assert!(
-            matches!(error, RequestParamsError::MultipleResources),
-            "expected multiple-resources error, got {error:?}",
-        );
+        assert_eq!(error, RequestParamsError::MultipleResources);
     }
 
     /// Rejects requests that omit the required `resource` parameter.
@@ -344,10 +371,7 @@ mod tests {
     fn rejects_missing_resource_param() {
         let error = "rel=profile".parse::<RequestParams>().unwrap_err();
 
-        assert!(
-            matches!(error, RequestParamsError::MissingResource),
-            "expected missing-resource error, got {error:?}",
-        );
+        assert_eq!(error, RequestParamsError::MissingResource);
     }
 
     /// Rejects relative references in the `resource` parameter.
@@ -368,13 +392,24 @@ mod tests {
         ] {
             let error = query.parse::<RequestParams>().unwrap_err();
 
-            assert!(
-                matches!(
-                    error,
-                    RequestParamsError::InvalidResource(ResourceError::RelativeReference)
-                ),
-                "expected relative-resource error, got {error:?}",
+            assert_eq!(
+                error,
+                RequestParamsError::InvalidResource(ResourceError::RelativeReference)
             );
         }
+    }
+
+    /// Exposes the resource parse error as the source of invalid-resource query failures.
+    ///
+    /// Adapters render all malformed queries as bad requests, but preserving the source keeps
+    /// logs and direct error handling specific enough to explain what was invalid.
+    #[test]
+    fn invalid_resource_error_exposes_source_error() {
+        let error = "resource=/relative".parse::<RequestParams>().unwrap_err();
+
+        assert_eq!(
+            error.source().map(ToString::to_string),
+            Some("resource must be an absolute URI".to_string())
+        );
     }
 }

--- a/webfinger-rs/src/reqwest.rs
+++ b/webfinger-rs/src/reqwest.rs
@@ -6,6 +6,7 @@ use tracing::trace;
 use crate::error::Error;
 use crate::{WebFingerRequest, WebFingerResponse};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct EmptyBody;
 
 static DEFAULT_CRYPTO_PROVIDER: Once = Once::new();
@@ -234,9 +235,57 @@ impl async_convert::TryFrom<reqwest::Response> for WebFingerResponse {
 
 #[cfg(test)]
 mod tests {
+    use http::StatusCode;
+    use http::header::CONTENT_TYPE;
     use reqwest::Method;
 
     use super::*;
+
+    fn reqwest_response(status: StatusCode, body: &'static str) -> reqwest::Response {
+        http::Response::builder()
+            .status(status)
+            .header(CONTENT_TYPE, "application/jrd+json")
+            .body(body)
+            .unwrap()
+            .into()
+    }
+
+    /// Converts the typed request into the exact Reqwest method and URL shape sent on the wire.
+    ///
+    /// This is the low-level inspection path callers can use before execution, and it should match
+    /// the RFC 7033 query encoding used by the `http::Uri` conversion.
+    #[test]
+    fn try_into_reqwest_builds_get_request() {
+        let request = WebFingerRequest::builder("acct:carol@example.org")
+            .unwrap()
+            .host("example.org")
+            .rel("avatar")
+            .build();
+
+        let reqwest_request = request.try_into_reqwest().unwrap();
+
+        assert_eq!(reqwest_request.method(), Method::GET);
+        assert_eq!(
+            reqwest_request.url().as_str(),
+            "https://example.org/.well-known/webfinger?resource=acct%3Acarol%40example.org&rel=avatar",
+        );
+    }
+
+    /// Surfaces invalid endpoint hosts as request-construction failures.
+    ///
+    /// Host validation happens when the typed WebFinger request is lowered into an HTTP request, so
+    /// this guards the error variant callers see before any transport is involved.
+    #[test]
+    fn try_into_reqwest_rejects_invalid_host() {
+        let request = WebFingerRequest::builder("acct:carol@example.org")
+            .unwrap()
+            .host("exa mple.org")
+            .build();
+
+        let error = request.try_into_reqwest().expect_err("invalid host");
+
+        assert!(matches!(error, Error::Http(_)));
+    }
 
     /// RFC 7033 sections 4.2 and 9.1 require WebFinger clients to use HTTPS-only transport. The
     /// first-party client should reject an HTTP URL before attempting network I/O; the same Reqwest
@@ -253,5 +302,57 @@ mod tests {
 
         assert!(error.is_builder());
         assert_eq!(error.url().map(reqwest::Url::scheme), Some("http"));
+    }
+
+    /// Parses a successful HTTP response through the public response-conversion helper.
+    ///
+    /// Applications may execute requests themselves and still rely on this crate for JRD status
+    /// handling and JSON decoding, so the helper needs direct coverage independent of networking.
+    #[tokio::test]
+    async fn try_from_reqwest_parses_success_response() {
+        let body = r#"{"subject":"acct:carol@example.org","links":[{"rel":"avatar"}]}"#;
+        let response = reqwest_response(StatusCode::OK, body);
+
+        let response = WebFingerResponse::try_from_reqwest(response).await.unwrap();
+
+        assert_eq!(
+            response,
+            WebFingerResponse::builder("acct:carol@example.org")
+                .link(crate::Link::builder("avatar"))
+                .build()
+        );
+    }
+
+    /// Rejects non-success statuses before attempting to parse the JRD body.
+    ///
+    /// Reqwest owns HTTP status classification here, and callers should receive the same error
+    /// family for status failures as for other response-handling failures.
+    #[tokio::test]
+    async fn try_from_reqwest_rejects_error_status() {
+        let response = reqwest_response(
+            StatusCode::NOT_FOUND,
+            r#"{"subject":"acct:carol@example.org","links":[]}"#,
+        );
+
+        let error = WebFingerResponse::try_from_reqwest(response)
+            .await
+            .expect_err("error status");
+
+        assert!(matches!(error, Error::Reqwest(_)));
+    }
+
+    /// Rejects malformed JSON bodies after a successful status.
+    ///
+    /// This keeps the response conversion contract narrow: success requires both a successful HTTP
+    /// status and a valid WebFinger JRD JSON document.
+    #[tokio::test]
+    async fn try_from_reqwest_rejects_invalid_json() {
+        let response = reqwest_response(StatusCode::OK, "not json");
+
+        let error = WebFingerResponse::try_from_reqwest(response)
+            .await
+            .expect_err("invalid json");
+
+        assert!(matches!(error, Error::Reqwest(_)));
     }
 }

--- a/webfinger-rs/src/types/jrd_uri.rs
+++ b/webfinger-rs/src/types/jrd_uri.rs
@@ -262,11 +262,18 @@ mod tests {
     {
     }
 
+    /// Locks the expected trait surface for a URI value type.
+    ///
+    /// `JrdUri` appears in maps, serialized JRDs, debug output, and public builders, so missing
+    /// common traits would make otherwise ordinary caller code awkward.
     #[test]
     fn implements_applicable_common_traits() {
         assert_common_traits::<JrdUri>();
     }
 
+    /// Accepts absolute URI strings, including non-hierarchical URI schemes.
+    ///
+    /// JRD fields may use `acct:` and other absolute URI schemes, not only URLs with hosts.
     #[test]
     fn accepts_absolute_uri_strings() {
         let uri = JrdUri::try_new("acct:carol@example.com").unwrap();
@@ -274,6 +281,9 @@ mod tests {
         assert_eq!(uri.as_ref(), "acct:carol@example.com");
     }
 
+    /// Accepts borrowed URI text through the standard fallible conversion trait.
+    ///
+    /// Builder-like APIs can use `TryFrom<&str>` without depending on the inherent constructor.
     #[test]
     fn try_from_parses_valid_uri_strings() {
         let uri = JrdUri::try_from("acct:carol@example.com").unwrap();
@@ -281,6 +291,31 @@ mod tests {
         assert_eq!(uri.as_ref(), "acct:carol@example.com");
     }
 
+    /// Accepts owned URI text through the same validation path as borrowed URI text.
+    ///
+    /// Builders often receive owned configuration strings, so `TryFrom<String>` should not drift
+    /// from the `&str` implementation.
+    #[test]
+    fn try_from_string_parses_valid_uri_strings() {
+        let uri = JrdUri::try_from("acct:carol@example.com".to_string()).unwrap();
+
+        assert_eq!(uri.as_ref(), "acct:carol@example.com");
+    }
+
+    /// Parses and displays JRD URI values through the standard string traits.
+    ///
+    /// These impls are what callers get from `"..." .parse()` and `{uri}` formatting, so they
+    /// should stay aligned with the explicit constructors.
+    #[test]
+    fn standard_string_traits_use_inner_uri_text() {
+        let uri = "acct:carol@example.com".parse::<JrdUri>().unwrap();
+
+        assert_eq!(uri.to_string(), "acct:carol@example.com");
+    }
+
+    /// Converts back into owned text without normalizing the URI string.
+    ///
+    /// Serialized JRD values should preserve caller-provided URI text after validation.
     #[test]
     fn converts_back_into_owned_string() {
         let uri = JrdUri::new("acct:carol@example.com");
@@ -288,6 +323,10 @@ mod tests {
         assert_eq!(String::from(uri), "acct:carol@example.com");
     }
 
+    /// Supports borrowed lookup in maps keyed by `JrdUri`.
+    ///
+    /// Property maps are keyed by URI values, and callers should not need to allocate a `JrdUri`
+    /// just to look up a known property identifier.
     #[test]
     fn supports_borrowed_string_map_lookup() {
         let mut values = BTreeMap::new();
@@ -296,6 +335,9 @@ mod tests {
         assert_eq!(values.get("acct:carol@example.com"), Some(&"Carol"));
     }
 
+    /// Orders URI values by their serialized string form.
+    ///
+    /// This keeps map/set ordering deterministic and aligned with the text that appears in JSON.
     #[test]
     fn orders_by_uri_string() {
         let first = JrdUri::new("acct:alice@example.com");
@@ -304,6 +346,10 @@ mod tests {
         assert!(first < second);
     }
 
+    /// Rejects relative references before they can enter JRD URI-valued fields.
+    ///
+    /// RFC 7033's JRD URI members are absolute URI strings, so relative paths should fail at the
+    /// value boundary rather than during later serialization.
     #[test]
     fn rejects_relative_uri_references() {
         let error = JrdUri::try_new("/profile/carol").expect_err("relative URI");
@@ -311,6 +357,14 @@ mod tests {
         assert!(error.to_string().contains("invalid JRD URI"));
     }
 
+    /// Rejects text that does not start with an absolute URI scheme.
+    ///
+    /// RFC 7033 defines JRD URI-valued members as URI strings. RFC 3986 section 4.3 says an
+    /// absolute URI begins with a scheme followed by `:`, so account-like display text must not be
+    /// accepted as a JRD URI.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4>.
+    /// See <https://www.rfc-editor.org/rfc/rfc3986.html#section-4.3>.
     #[test]
     fn rejects_non_uri_strings() {
         let error = JrdUri::try_new("carol@example.com").expect_err("non-URI string");
@@ -318,9 +372,18 @@ mod tests {
         assert!(error.to_string().contains("invalid JRD URI"));
     }
 
+    /// Rejects malformed percent escapes in URI-valued fields.
+    ///
+    /// RFC 3986 percent escapes must be complete hexadecimal byte escapes; accepting malformed
+    /// values would serialize invalid JRD URI strings.
     #[test]
     fn rejects_malformed_percent_escapes() {
-        for uri in ["https://example.org/a%GG", "acct:carol%GG@example.com"] {
+        for uri in [
+            "https://example.org/a%GG",
+            "acct:carol%GG@example.com",
+            "https://example.org/a%",
+            "https://example.org/a%4",
+        ] {
             let error = JrdUri::try_new(uri).expect_err("malformed percent escape");
 
             assert!(
@@ -330,11 +393,25 @@ mod tests {
         }
     }
 
+    /// Applies the same absolute-URI validation when deserializing JSON.
+    ///
+    /// This prevents inbound JRD documents from bypassing `JrdUri::try_new` by using Serde.
     #[test]
     fn deserialization_rejects_relative_uri_references() {
         let error =
             serde_json::from_str::<JrdUri>(r#""/profile/carol""#).expect_err("relative URI");
 
         assert!(error.to_string().contains("invalid JRD URI"));
+    }
+
+    /// Rejects non-string JSON before URI syntax validation.
+    ///
+    /// JRD URI fields are JSON strings, so this guards the Serde visitor's type expectation rather
+    /// than the URI parser itself.
+    #[test]
+    fn deserialization_rejects_non_string_values() {
+        let error = serde_json::from_str::<JrdUri>("42").expect_err("number");
+
+        assert!(error.to_string().contains("absolute URI string"));
     }
 }

--- a/webfinger-rs/src/types/link.rs
+++ b/webfinger-rs/src/types/link.rs
@@ -420,6 +420,10 @@ mod tests {
     {
     }
 
+    /// Locks the expected trait surface for link data and builder values.
+    ///
+    /// Links are public JRD data, while builders often appear in tests before `.build()` is called;
+    /// both should stay ergonomic to clone, compare, sort, hash, and debug.
     #[test]
     fn implements_applicable_common_traits() {
         assert_data_traits::<Link>();
@@ -427,6 +431,10 @@ mod tests {
         assert_builder_traits::<LinkBuilder>();
     }
 
+    /// Serializes localized titles as the RFC JRD language-object shape.
+    ///
+    /// RFC 7033 section 4.4.4.4 defines `titles` as an object keyed by language tag, not as an
+    /// array of title entries.
     #[test]
     fn builder_serializes_titles_as_language_object() -> Result {
         let link = Link::builder("http://webfinger.net/rel/profile-page")
@@ -449,6 +457,10 @@ mod tests {
         Ok(())
     }
 
+    /// Serializes null link properties distinctly from absent properties.
+    ///
+    /// RFC 7033 allows property values to be `null`; callers use that to publish a known property
+    /// with no value rather than omitting the property key entirely.
     #[test]
     fn builder_serializes_template() -> Result {
         let link = Link::builder("http://ostatus.org/schema/1.0/subscribe")
@@ -488,9 +500,12 @@ mod tests {
 
     #[test]
     fn builder_serializes_null_properties() -> Result {
+        const OLD_ROLE_PROPERTY: &str = "https://example.com/ns/old-role";
+        const ROLE_PROPERTY: &str = "https://example.com/ns/role";
+
         let link = Link::builder("author")
-            .property("https://example.com/ns/role", "editor")
-            .null_property("https://example.com/ns/old-role")
+            .property(ROLE_PROPERTY, "editor")
+            .null_property(OLD_ROLE_PROPERTY)
             .build();
 
         let json = serde_json::to_value(link)?;
@@ -508,6 +523,132 @@ mod tests {
         Ok(())
     }
 
+    /// Keeps the direct constructor limited to the required relation member.
+    ///
+    /// Optional JRD link members should only appear when callers choose them through the builder or
+    /// direct struct construction, and the compact debug output should not print absent fields.
+    #[test]
+    fn new_sets_only_relation() {
+        let link = Link::new(Rel::new("avatar"));
+
+        assert_eq!(
+            link,
+            Link {
+                rel: Rel::new("avatar"),
+                r#type: None,
+                href: None,
+                template: None,
+                titles: None,
+                properties: None,
+            },
+        );
+    }
+
+    /// Omits absent optional fields from minimal link debug output.
+    #[test]
+    fn debug_omits_absent_optional_fields() {
+        let link = Link::new(Rel::new("avatar"));
+
+        assert_eq!(format!("{link:?}"), r#"Link { rel: Rel("avatar") }"#);
+    }
+
+    /// Covers the replacement-style builder methods that set whole optional objects at once.
+    ///
+    /// The one-at-a-time methods already have serialization coverage; this guards the bulk title
+    /// and property setters used when callers have pre-collected maps.
+    #[test]
+    fn builder_serializes_complete_title_and_property_maps() -> Result {
+        const LEGACY_PROPERTY: &str = "https://example.com/ns/legacy";
+        const ROLE_PROPERTY: &str = "https://example.com/ns/role";
+
+        let link = Link::builder("author")
+            .r#type("text/html")
+            .href("https://example.com/people/carol")
+            .titles([("en-us", "Carol"), ("fr", "Caroline")])
+            .properties([
+                (JrdUri::new(ROLE_PROPERTY), Some("editor".to_string())),
+                (JrdUri::new(LEGACY_PROPERTY), None),
+            ])
+            .build();
+
+        assert_eq!(
+            serde_json::to_value(link)?,
+            json!({
+                "rel": "author",
+                "type": "text/html",
+                "href": "https://example.com/people/carol",
+                "titles": {
+                    "en-us": "Carol",
+                    "fr": "Caroline"
+                },
+                "properties": {
+                    "https://example.com/ns/legacy": null,
+                    "https://example.com/ns/role": "editor"
+                }
+            })
+        );
+        Ok(())
+    }
+
+    /// Includes optional fields in debug output only when they are present.
+    ///
+    /// The custom debug formatter is meant to keep minimal links compact while still exposing
+    /// populated JRD members during test failures and logs.
+    #[test]
+    fn debug_includes_present_optional_fields() {
+        const ROLE_PROPERTY: &str = "https://example.com/ns/role";
+
+        let link = Link::builder("author")
+            .r#type("text/html")
+            .href("https://example.com/people/carol")
+            .title("en-us", "Carol")
+            .property(ROLE_PROPERTY, "editor")
+            .build();
+
+        assert_eq!(
+            format!("{link:?}"),
+            r#"Link { rel: Rel("author"), type: "text/html", href: JrdUri("https://example.com/people/carol"), titles: {"en-us": "Carol"}, properties: {JrdUri("https://example.com/ns/role"): Some("editor")} }"#
+        );
+    }
+
+    /// Keeps builder debug output recognizable while delegating field detail to `Link`.
+    ///
+    /// Builder values can appear in assertion failures before `.build()` is called, so their debug
+    /// shape should remain intentional rather than falling back to private field names.
+    #[test]
+    fn builder_debug_wraps_inner_link() {
+        let builder = Link::builder("author");
+
+        assert_eq!(
+            format!("{builder:?}"),
+            r#"LinkBuilder(Link { rel: Rel("author") })"#
+        );
+    }
+
+    /// Replaces a prior localized title with the same language key.
+    ///
+    /// JRD titles are an object keyed by language tag, so adding the same language twice should
+    /// behave like map insertion rather than producing a duplicate title entry.
+    #[test]
+    fn title_replaces_existing_language() {
+        let link = Link::builder("author")
+            .title("en-us", "Carol")
+            .title("en-us", "Carol Smith")
+            .build();
+
+        assert_eq!(
+            link.titles
+                .as_ref()
+                .and_then(|titles| titles.get("en-us"))
+                .map(String::as_str),
+            Some("Carol Smith")
+        );
+    }
+
+    /// Rejects array-shaped localized titles.
+    ///
+    /// This guards the RFC JRD object shape for `titles` rather than accepting a more generic
+    /// language/value list shape.
     #[test]
     fn deserialization_rejects_title_array_shape() {
         let json = r#"
@@ -527,6 +668,10 @@ mod tests {
         assert!(error.to_string().contains("invalid type"));
     }
 
+    /// Rejects relative URI property identifiers during link deserialization.
+    ///
+    /// Link property names are JRD URI strings, so accepting relative keys would create an invalid
+    /// typed `Link` from inbound JSON.
     #[test]
     fn deserialization_rejects_relative_property_identifiers() {
         let json = r#"

--- a/webfinger-rs/src/types/rel.rs
+++ b/webfinger-rs/src/types/rel.rs
@@ -199,11 +199,19 @@ mod tests {
     {
     }
 
+    /// Locks the expected trait surface for a relation value type.
+    ///
+    /// Relations are stored in vectors and sets, serialized into JRD links, and compared by
+    /// servers applying relation filters, so common value traits should remain available.
     #[test]
     fn implements_applicable_common_traits() {
         assert_common_traits::<Rel>();
     }
 
+    /// Accepts URI relation types.
+    ///
+    /// RFC 5988 allows extension relation types as URI strings, which WebFinger commonly uses for
+    /// profile-page and other application-specific relations.
     #[test]
     fn accepts_uri_relation_types() {
         let rel = Rel::try_new("http://webfinger.net/rel/profile-page").unwrap();
@@ -211,6 +219,10 @@ mod tests {
         assert_eq!(rel.as_ref(), "http://webfinger.net/rel/profile-page");
     }
 
+    /// Accepts registered relation type names.
+    ///
+    /// RFC 5988 also allows registered relation names such as `author`; not every relation filter
+    /// needs to be a URI.
     #[test]
     fn accepts_registered_relation_types() {
         let rel = Rel::try_new("author").unwrap();
@@ -218,6 +230,9 @@ mod tests {
         assert_eq!(rel.as_ref(), "author");
     }
 
+    /// Accepts borrowed relation text through the standard fallible conversion trait.
+    ///
+    /// This keeps generic conversion code aligned with the explicit `Rel::try_new` constructor.
     #[test]
     fn try_from_parses_valid_relation_types() {
         let rel = Rel::try_from("author").unwrap();
@@ -225,6 +240,32 @@ mod tests {
         assert_eq!(rel.as_ref(), "author");
     }
 
+    /// Accepts owned relation text through the same validation path as borrowed relation text.
+    ///
+    /// CLI and configuration code commonly collect relation filters as `String`s, so this guards
+    /// the owned conversion used before request construction.
+    #[test]
+    fn try_from_string_parses_valid_relation_types() {
+        let rel = Rel::try_from("author".to_string()).unwrap();
+
+        assert_eq!(rel.as_ref(), "author");
+    }
+
+    /// Parses relation values through the standard string trait.
+    ///
+    /// This is the idiomatic API callers reach for when relation text comes from a config file or
+    /// request parameter rather than from builder literals.
+    #[test]
+    fn from_str_parses_valid_relation_types() {
+        let rel = "author".parse::<Rel>().unwrap();
+
+        assert_eq!(rel.as_ref(), "author");
+    }
+
+    /// Converts back into owned text without changing the relation value.
+    ///
+    /// Request construction and response serialization should preserve the relation token callers
+    /// supplied after validation.
     #[test]
     fn converts_back_into_owned_string() {
         let rel = Rel::new("author");
@@ -232,6 +273,10 @@ mod tests {
         assert_eq!(String::from(rel), "author");
     }
 
+    /// Supports borrowed lookup in sets keyed by `Rel`.
+    ///
+    /// Servers filtering responses by relation should not need to allocate a `Rel` just to check
+    /// whether a known relation is present.
     #[test]
     fn supports_borrowed_string_set_lookup() {
         let mut values = BTreeSet::new();
@@ -240,6 +285,10 @@ mod tests {
         assert!(values.contains("author"));
     }
 
+    /// Orders relation values by their serialized string form.
+    ///
+    /// This keeps ordered collections deterministic and aligned with the relation text that appears
+    /// in request and response payloads.
     #[test]
     fn orders_by_relation_string() {
         let first = Rel::new("author");
@@ -248,6 +297,9 @@ mod tests {
         assert!(first < second);
     }
 
+    /// Rejects empty relation values before request or response construction.
+    ///
+    /// Empty relation strings are neither registered relation names nor URI relation types.
     #[test]
     fn rejects_empty_relation_types() {
         let error = Rel::try_new("").expect_err("empty relation type");
@@ -255,6 +307,12 @@ mod tests {
         assert!(error.to_string().contains("invalid relation type"));
     }
 
+    /// Rejects a space-separated relation list in a single `rel` value.
+    ///
+    /// RFC 7033 section 4.4.4.1 says each link object has one relation type. Multiple relation
+    /// filters belong in repeated request `rel` parameters, not in one relation string.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.4.4.1>.
     #[test]
     fn rejects_multiple_relation_types_in_one_value() {
         let error = Rel::try_new("author avatar").expect_err("multiple relation types");
@@ -262,6 +320,14 @@ mod tests {
         assert!(error.to_string().contains("invalid relation type"));
     }
 
+    /// Rejects URI-shaped relation values unless they are absolute URIs.
+    ///
+    /// RFC 5988 section 5.3 allows extension relation types as URIs, and RFC 3986 section 4.3
+    /// defines the absolute-URI shape. A relative reference would not identify a globally scoped
+    /// relation type.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc5988.html#section-5.3>.
+    /// See <https://www.rfc-editor.org/rfc/rfc3986.html#section-4.3>.
     #[test]
     fn rejects_relative_uri_relation_types() {
         let error = Rel::try_new("/rel/profile-page").expect_err("relative URI relation type");
@@ -269,6 +335,9 @@ mod tests {
         assert!(error.to_string().contains("invalid relation type"));
     }
 
+    /// Rejects malformed percent escapes in URI-shaped relation values.
+    ///
+    /// Extension relation URIs still need to be valid absolute URI strings under RFC 3986.
     #[test]
     fn rejects_uri_relation_types_with_malformed_percent_escapes() {
         let error = Rel::try_new("http://example.com/a%GG").expect_err("malformed percent escape");
@@ -276,10 +345,28 @@ mod tests {
         assert!(error.to_string().contains("invalid relation type"));
     }
 
+    /// Applies relation validation when deserializing JSON link objects.
+    ///
+    /// Inbound JRD documents should not be able to bypass `Rel::try_new` through Serde.
     #[test]
     fn deserialization_rejects_invalid_relation_types() {
         let error = serde_json::from_str::<Rel>(r#""""#).expect_err("empty relation type");
 
         assert!(error.to_string().contains("invalid relation type"));
+    }
+
+    /// Rejects non-string JSON before relation syntax validation.
+    ///
+    /// Relation values are serialized as JSON strings; a numeric value is a shape error even if its
+    /// rendered text could otherwise look like a registered relation token.
+    #[test]
+    fn deserialization_rejects_non_string_values() {
+        let error = serde_json::from_str::<Rel>("42").expect_err("number");
+
+        assert!(
+            error
+                .to_string()
+                .contains("URI relation type or registered relation type")
+        );
     }
 }

--- a/webfinger-rs/src/types/request.rs
+++ b/webfinger-rs/src/types/request.rs
@@ -320,4 +320,61 @@ mod tests {
             "https://blog.example.com/.well-known/webfinger?resource=http%3A%2F%2Fblog.example.com%2Farticle%2Fid%2F314",
         );
     }
+
+    /// Keeps the low-level constructor intentionally minimal.
+    ///
+    /// `Request::new` accepts an already validated resource but does not infer a host or relation
+    /// filters; callers must opt into those pieces through the builder or direct field assignment.
+    #[test]
+    fn new_starts_with_resource_only() {
+        let resource = Resource::try_from("acct:carol@example.com").unwrap();
+
+        let request = Request::new(resource.clone());
+
+        assert_eq!(
+            request,
+            Request {
+                resource,
+                host: String::new(),
+                rels: Vec::new(),
+            }
+        );
+    }
+
+    /// Covers the ergonomic builder path used by docs and callers.
+    ///
+    /// The builder is the public API that translates string inputs into the typed request fields,
+    /// so it should preserve host text and repeated relation order exactly.
+    #[test]
+    fn builder_sets_host_and_rels() {
+        let request = Request::builder("acct:carol@example.com")
+            .unwrap()
+            .host("example.com")
+            .rel("http://webfinger.net/rel/profile-page")
+            .rel("avatar")
+            .build();
+
+        assert_eq!(
+            request,
+            Request {
+                host: "example.com".to_string(),
+                resource: Resource::try_from("acct:carol@example.com").unwrap(),
+                rels: vec![
+                    Rel::new("http://webfinger.net/rel/profile-page"),
+                    Rel::new("avatar"),
+                ],
+            }
+        );
+    }
+
+    /// Rejects relative resources at builder construction time.
+    ///
+    /// This keeps invalid input from being stored in a partially usable builder and matches the
+    /// stricter first-party extractor behavior for incoming WebFinger requests.
+    #[test]
+    fn builder_rejects_relative_resource() {
+        let error = Request::builder("/users/carol").expect_err("relative resource");
+
+        assert!(matches!(error, Error::InvalidResource(_)));
+    }
 }

--- a/webfinger-rs/src/types/resource.rs
+++ b/webfinger-rs/src/types/resource.rs
@@ -32,6 +32,25 @@ pub enum ResourceError {
     MissingHttpAuthority,
 }
 
+// `http::uri::InvalidUri` does not implement `PartialEq` or `Eq`, so this cannot be derived.
+// See https://github.com/hyperium/http/issues/849.
+impl PartialEq for ResourceError {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::RelativeReference, Self::RelativeReference)
+            | (Self::InvalidCharacters, Self::InvalidCharacters)
+            | (Self::InvalidPercentEncoding, Self::InvalidPercentEncoding)
+            | (Self::MissingHttpAuthority, Self::MissingHttpAuthority) => true,
+            (Self::InvalidHttpUri(left), Self::InvalidHttpUri(right)) => {
+                left.to_string() == right.to_string()
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Eq for ResourceError {}
+
 /// A WebFinger resource URI.
 ///
 /// RFC 7033 uses the `resource` query parameter for the query target, which is a URI rather than a
@@ -294,6 +313,9 @@ mod tests {
     }
 
     /// Accepts hierarchical HTTPS resources with an authority.
+    ///
+    /// Host extraction is used by the CLI fallback path, so this test covers both storage of the
+    /// original resource text and the derived host/URI accessors.
     #[test]
     fn accepts_https_resource() {
         let resource = "https://example.org/users/carol"
@@ -302,6 +324,22 @@ mod tests {
 
         assert_eq!(resource.as_str(), "https://example.org/users/carol");
         assert_eq!(resource.host(), Some("example.org"));
+        assert_eq!(
+            resource.uri().map(|uri| uri.to_string()),
+            Some("https://example.org/users/carol".to_string()),
+        );
+    }
+
+    /// Accepts owned resource text through the same validation path as parsed `&str` input.
+    ///
+    /// The owned conversion preserves the original text because downstream request encoding should
+    /// not normalize or otherwise rewrite caller-provided resource URIs.
+    #[test]
+    fn try_from_string_preserves_resource_text() {
+        let resource = Resource::try_from("acct:carol@example.com".to_string()).unwrap();
+
+        assert_eq!(resource.as_str(), "acct:carol@example.com");
+        assert_eq!(resource.to_string(), "acct:carol@example.com");
     }
 
     /// Accepts scheme-specific opaque-looking URIs.
@@ -318,15 +356,27 @@ mod tests {
     }
 
     /// Rejects relative references that `http::Uri` can otherwise parse.
+    ///
+    /// RFC 7033 section 4.1 defines `resource` as a URI identifying the target resource. RFC 3986
+    /// section 4.2 relative references are not enough because they have no standalone scheme.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-4.1>.
+    /// See <https://www.rfc-editor.org/rfc/rfc3986.html#section-4.2>.
     #[test]
     fn rejects_relative_resource_references() {
-        for resource in ["carol", "/relative", "../x", ""] {
+        for resource in [
+            "carol",
+            "/relative",
+            "?resource=acct:carol@example.com",
+            "#fragment",
+            "../x",
+            "",
+            "1acct:carol@example.com",
+            "ac_ct:carol@example.org",
+        ] {
             let error = resource.parse::<Resource>().unwrap_err();
 
-            assert!(
-                matches!(error, ResourceError::RelativeReference),
-                "expected relative-resource error for {resource:?}, got {error:?}",
-            );
+            assert_eq!(error, ResourceError::RelativeReference);
         }
     }
 
@@ -338,10 +388,7 @@ mod tests {
     fn rejects_non_ascii_resource_text() {
         let error = "acct:carolé@example.org".parse::<Resource>().unwrap_err();
 
-        assert!(
-            matches!(error, ResourceError::InvalidCharacters),
-            "expected invalid-character error, got {error:?}",
-        );
+        assert_eq!(error, ResourceError::InvalidCharacters);
     }
 
     /// Rejects raw ASCII characters outside the RFC 3986 URI character set.
@@ -355,10 +402,7 @@ mod tests {
         ] {
             let error = resource.parse::<Resource>().unwrap_err();
 
-            assert!(
-                matches!(error, ResourceError::InvalidCharacters),
-                "expected invalid-character error for {resource:?}, got {error:?}",
-            );
+            assert_eq!(error, ResourceError::InvalidCharacters);
         }
     }
 
@@ -378,12 +422,15 @@ mod tests {
     /// decoded, so malformed escapes must be rejected at the resource boundary too.
     #[test]
     fn rejects_malformed_resource_percent_escape() {
-        let error = "acct:carol%GG@example.org".parse::<Resource>().unwrap_err();
+        for resource in [
+            "acct:carol%GG@example.org",
+            "acct:carol%@example.org",
+            "acct:carol%4@example.org",
+        ] {
+            let error = resource.parse::<Resource>().unwrap_err();
 
-        assert!(
-            matches!(error, ResourceError::InvalidPercentEncoding),
-            "expected invalid-percent-encoding error, got {error:?}",
-        );
+            assert_eq!(error, ResourceError::InvalidPercentEncoding);
+        }
     }
 
     /// Rejects HTTP and HTTPS resources that omit the required authority.
@@ -392,10 +439,7 @@ mod tests {
         for resource in ["http:foo", "https:foo", "http:/example.org/path"] {
             let error = resource.parse::<Resource>().unwrap_err();
 
-            assert!(
-                matches!(error, ResourceError::MissingHttpAuthority),
-                "expected missing-authority error for {resource:?}, got {error:?}",
-            );
+            assert_eq!(error, ResourceError::MissingHttpAuthority);
         }
     }
 
@@ -405,11 +449,13 @@ mod tests {
     /// hierarchical URI validation used for HTTP resources.
     #[test]
     fn rejects_invalid_https_authority_with_uppercase_scheme() {
-        let error = "HTTPS://[::1".parse::<Resource>().unwrap_err();
+        for resource in ["HTTPS://[::1", "https:///profile"] {
+            let error = resource.parse::<Resource>().unwrap_err();
 
-        assert!(
-            matches!(error, ResourceError::InvalidHttpUri(_)),
-            "expected invalid-authority error, got {error:?}",
-        );
+            assert!(
+                matches!(error, ResourceError::InvalidHttpUri(_)),
+                "expected invalid-authority error for {resource:?}, got {error:?}",
+            );
+        }
     }
 }

--- a/webfinger-rs/src/types/response.rs
+++ b/webfinger-rs/src/types/response.rs
@@ -368,12 +368,21 @@ mod tests {
     {
     }
 
+    /// Locks the expected trait surface for response data and builder values.
+    ///
+    /// Responses are public JRD data used in maps, test assertions, serialization, and debug logs;
+    /// builders should also remain easy to clone and compare while constructing fixtures.
     #[test]
     fn implements_applicable_common_traits() {
         assert_data_traits::<Response>();
         assert_builder_traits::<Builder>();
     }
 
+    /// Deserializes a representative RFC-shaped JRD document.
+    ///
+    /// This covers the nested object shapes that are easy to accidentally model as simpler maps or
+    /// lists: response properties, link titles, link properties, and explicit `null` property
+    /// values.
     #[test]
     fn deserializes_rfc_shaped_jrd_with_null_properties_and_title_object() -> Result {
         let json = r#"
@@ -446,18 +455,27 @@ mod tests {
         Ok(())
     }
 
+    /// Serializes builder output into the RFC JRD object shape.
+    ///
+    /// This is the inverse of the deserialization coverage above: builders should produce the same
+    /// aliases, properties, link titles, link properties, and `null` values that inbound JRDs use.
     #[test]
     fn serializes_builder_output_as_rfc_shaped_jrd() -> Result {
+        const LEGACY_LINK_PROPERTY: &str = "https://example.com/ns/legacy";
+        const OLD_ROLE_PROPERTY: &str = "https://example.com/ns/old-role";
+        const ROLE_PROPERTY: &str = "https://example.com/ns/role";
+        const VERIFIED_PROPERTY: &str = "https://example.com/ns/verified";
+
         let response = Response::builder("acct:carol@example.com")
             .alias("https://example.com/profile/carol")
-            .property("https://example.com/ns/role", "developer")
-            .null_property("https://example.com/ns/old-role")
+            .property(ROLE_PROPERTY, "developer")
+            .null_property(OLD_ROLE_PROPERTY)
             .link(
                 Link::builder("http://webfinger.net/rel/profile-page")
                     .href("https://example.com/profile/carol")
                     .title("en-us", "Carol's Profile")
-                    .property("https://example.com/ns/verified", "true")
-                    .null_property("https://example.com/ns/legacy"),
+                    .property(VERIFIED_PROPERTY, "true")
+                    .null_property(LEGACY_LINK_PROPERTY),
             )
             .build();
 
@@ -490,6 +508,123 @@ mod tests {
         Ok(())
     }
 
+    /// Keeps the direct constructor focused on the required JRD subject.
+    ///
+    /// Optional members are intentionally absent until requested, while `links` remains an empty
+    /// array because response code can iterate links without handling a missing field.
+    #[test]
+    fn new_sets_required_subject_only() {
+        let response = Response::new("acct:carol@example.com");
+
+        assert_eq!(
+            response,
+            Response {
+                subject: JrdUri::new("acct:carol@example.com"),
+                aliases: None,
+                properties: None,
+                links: Vec::new(),
+            },
+        );
+    }
+
+    /// Serializes minimal responses with the required subject and an empty link array.
+    #[test]
+    fn new_serializes_required_subject_and_empty_links() -> Result {
+        let response = Response::new("acct:carol@example.com");
+
+        assert_eq!(
+            serde_json::to_value(&response)?,
+            json!({
+                "subject": "acct:carol@example.com",
+                "links": []
+            }),
+        );
+        Ok(())
+    }
+
+    /// Pretty-prints responses through the same JSON shape exposed to callers.
+    #[test]
+    fn display_pretty_prints_response_json() {
+        let response = Response::new("acct:carol@example.com");
+
+        assert_eq!(
+            response.to_string(),
+            "{\n  \"subject\": \"acct:carol@example.com\",\n  \"links\": []\n}"
+        );
+    }
+
+    /// Omits absent optional fields from minimal response debug output.
+    #[test]
+    fn debug_omits_absent_optional_fields() {
+        let response = Response::new("acct:carol@example.com");
+
+        assert_eq!(
+            format!("{response:?}"),
+            r#"Response { subject: JrdUri("acct:carol@example.com"), links: [] }"#
+        );
+    }
+
+    /// Rejects invalid subjects through the fallible builder path.
+    ///
+    /// `Response::builder` is intentionally convenient and panicking for trusted strings; this
+    /// fallible constructor is the API external input should use instead.
+    #[test]
+    fn try_builder_rejects_relative_subject() {
+        let error = Response::try_builder("/users/carol").expect_err("relative subject");
+
+        assert!(matches!(error, Error::InvalidJrdUri(uri) if uri == "/users/carol"));
+    }
+
+    /// Replaces the complete link array when callers already have a collected list.
+    ///
+    /// This distinguishes `links(...)` from `link(...)`, which appends one item at a time.
+    #[test]
+    fn links_replaces_existing_link_array() {
+        let response = Response::builder("acct:carol@example.com")
+            .link(Link::builder("author"))
+            .links(vec![Link::builder("avatar").build()])
+            .build();
+
+        assert_eq!(response.links, vec![Link::builder("avatar").build()]);
+    }
+
+    /// Includes optional response objects in debug output only when present.
+    ///
+    /// The custom debug formatter keeps minimal responses short, but populated responses should
+    /// still expose aliases and properties when a test or log captures the value.
+    #[test]
+    fn debug_includes_present_optional_fields() {
+        const ROLE_PROPERTY: &str = "https://example.com/ns/role";
+
+        let response = Response::builder("acct:carol@example.com")
+            .alias("https://example.com/people/carol")
+            .property(ROLE_PROPERTY, "admin")
+            .build();
+
+        assert_eq!(
+            format!("{response:?}"),
+            r#"Response { subject: JrdUri("acct:carol@example.com"), aliases: [JrdUri("https://example.com/people/carol")], properties: {JrdUri("https://example.com/ns/role"): Some("admin")}, links: [] }"#
+        );
+    }
+
+    /// Keeps builder debug output recognizable while delegating field detail to `Response`.
+    ///
+    /// Builder values can appear in assertion failures before `.build()` is called, so their debug
+    /// shape should remain intentional rather than exposing private field names.
+    #[test]
+    fn builder_debug_wraps_inner_response() {
+        let builder = Response::builder("acct:carol@example.com");
+
+        assert_eq!(
+            format!("{builder:?}"),
+            r#"Builder(Response { subject: JrdUri("acct:carol@example.com"), links: [] })"#
+        );
+    }
+
+    /// Rejects relative URI-valued fields in inbound JRD documents.
+    ///
+    /// Link `href` values are JRD URI strings, so relative references should fail during
+    /// deserialization instead of entering typed response data.
     #[test]
     fn rejects_relative_jrd_uris() {
         let json =
@@ -500,6 +635,10 @@ mod tests {
         assert!(error.to_string().contains("invalid JRD URI"));
     }
 
+    /// Rejects invalid relation values inside inbound JRD links.
+    ///
+    /// Response deserialization should enforce the same `Rel` boundary as builders and request
+    /// filters.
     #[test]
     fn rejects_empty_relation_types() {
         let json = r#"{"subject":"acct:carol@example.com","links":[{"rel":""}]}"#;
@@ -509,6 +648,10 @@ mod tests {
         assert!(error.to_string().contains("invalid relation type"));
     }
 
+    /// Defaults missing `links` to an empty collection.
+    ///
+    /// RFC-shaped JRDs can omit optional members; typed response code should still be able to
+    /// iterate links without handling `None`.
     #[test]
     fn deserializes_jrd_without_links() -> Result {
         let json = r#"{"subject":"acct:carol@example.com"}"#;

--- a/webfinger-rs/tests/reqwest_axum.rs
+++ b/webfinger-rs/tests/reqwest_axum.rs
@@ -1,0 +1,104 @@
+#![cfg(all(feature = "axum", feature = "reqwest"))]
+
+use std::net::{Ipv4Addr, SocketAddr, TcpListener};
+use std::sync::Once;
+
+use axum::Router;
+use axum::routing::get;
+use axum_server::tls_rustls::RustlsConfig;
+use http::StatusCode;
+use webfinger_rs::{Link, Rel, WELL_KNOWN_PATH, WebFingerRequest, WebFingerResponse};
+
+const PROFILE_PAGE_REL: &str = "http://webfinger.net/rel/profile-page";
+const PROFILE_URL: &str = "https://localhost/users/carol";
+const SUBJECT: &str = "acct:carol@localhost";
+
+static DEFAULT_CRYPTO_PROVIDER: Once = Once::new();
+
+type TestResult<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+struct TestServer {
+    addr: SocketAddr,
+    client: reqwest::Client,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+fn install_default_crypto_provider() {
+    DEFAULT_CRYPTO_PROVIDER.call_once(|| {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    });
+}
+
+async fn https_webfinger_server() -> TestResult<TestServer> {
+    install_default_crypto_provider();
+
+    let self_signed_cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])?;
+    let cert = self_signed_cert.cert.der().to_vec();
+    let key = self_signed_cert.signing_key.serialize_der();
+    let config = RustlsConfig::from_der(vec![cert.clone()], key).await?;
+    let client = reqwest::Client::builder()
+        .https_only(true)
+        // The integration boundary here is the HTTP conversation over TLS, not platform PKI.
+        // Windows rejects this rcgen self-signed certificate as an unknown issuer even when it is
+        // added as a reqwest root, so keep certificate validation out of this portable test.
+        .danger_accept_invalid_certs(true)
+        .build()?;
+
+    let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
+    let listener = TcpListener::bind(addr)?;
+    let addr = listener.local_addr()?;
+    listener.set_nonblocking(true)?;
+    let app = Router::new().route(WELL_KNOWN_PATH, get(webfinger));
+    let server = axum_server::from_tcp_rustls(listener, config)?.serve(app.into_make_service());
+    let task = tokio::spawn(async move {
+        let _ = server.await;
+    });
+
+    Ok(TestServer { addr, client, task })
+}
+
+async fn webfinger(request: WebFingerRequest) -> axum::response::Result<WebFingerResponse> {
+    if request.resource.as_ref() != SUBJECT {
+        return Err((StatusCode::NOT_FOUND, "not found").into());
+    }
+
+    let profile_rel = Rel::new(PROFILE_PAGE_REL);
+    let links = if request.rels.is_empty() || request.rels.contains(&profile_rel) {
+        vec![Link::builder(profile_rel).href(PROFILE_URL).build()]
+    } else {
+        Vec::new()
+    };
+
+    Ok(WebFingerResponse::builder(SUBJECT).links(links).build())
+}
+
+/// Exercises a complete HTTPS WebFinger conversation between this crate's Reqwest client path and
+/// Axum server adapter.
+///
+/// The narrower response-shim unit tests cover status and JSON conversion without I/O. This test
+/// crosses a localhost socket to catch integration breakage in URI construction, TLS transport,
+/// Axum extraction, response serialization, and Reqwest decoding.
+#[tokio::test]
+async fn execute_reqwest_with_client_fetches_from_axum_server() -> TestResult {
+    let server = https_webfinger_server().await?;
+    let request = WebFingerRequest::builder(SUBJECT)?
+        .host(format!("localhost:{}", server.addr.port()))
+        .rel(PROFILE_PAGE_REL)
+        .build();
+
+    let response = request.execute_reqwest_with_client(&server.client).await?;
+
+    assert_eq!(
+        response,
+        WebFingerResponse::builder(SUBJECT)
+            .link(Link::builder(PROFILE_PAGE_REL).href(PROFILE_URL))
+            .build()
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- expand library, CLI, reqwest, and framework coverage for WebFinger parsing and response behavior
- add trait derivations and owned error sources where the API can support them
- document RFC-backed and non-obvious test rationale, including the `InvalidUri` equality limitation
- add an integration test that exercises reqwest against an Axum WebFinger server over TLS

## Validation

- `cargo fmt --all --check`
- `cargo test --workspace --all-features --quiet`
- `cargo clippy --workspace --all-features --all-targets --quiet`
- `cargo llvm-cov --workspace --all-features --all-targets --summary-only` (`88.90%` line coverage)
