### PR TITLE
Add Cloudflare WebFinger worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /node_modules
 /.wrangler
 /webfinger-viewer-worker/build
+/webfinger-service-worker/build

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -4,6 +4,7 @@
   ],
   "ignores": [
     "target/**",
+    "node_modules/**",
     ".jj/**",
     ".git/**"
   ],

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "time",
  "tracing",
  "url",
@@ -281,9 +281,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.9.0"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -338,14 +338,14 @@ dependencies = [
  "serde",
  "serde_derive",
  "unicode-ident",
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "asn1-rs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -353,7 +353,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
 ]
 
@@ -408,15 +408,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -424,14 +424,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -549,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bs58"
@@ -564,42 +565,36 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "bytestring"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113b4343b5f6617e7ad401ced8de3cc8b012e73a594347c307b90db3e9271289"
+checksum = "86566c496f2f47d9b8147a4c8b02ffdb69c919fe0c2b2e7195d22cbba0e635c9"
 dependencies = [
  "bytes",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -609,9 +604,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -815,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der-parser"
@@ -839,7 +834,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -868,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -891,9 +885,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encoding_rs"
@@ -959,9 +953,9 @@ dependencies = [
 
 [[package]]
 name = "fs-err"
-version = "3.3.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
 dependencies = [
  "autocfg",
  "tokio",
@@ -1080,7 +1074,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1089,9 +1083,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1099,7 +1093,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.2",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1114,9 +1108,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1188,22 +1182,21 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2 0.4.15",
  "http 1.4.2",
  "http-body",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1211,15 +1204,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.2",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1242,7 +1234,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -1274,12 +1266,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1287,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1300,9 +1293,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1314,15 +1307,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1334,15 +1327,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1372,9 +1365,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1411,12 +1404,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1441,27 +1434,32 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
@@ -1539,9 +1537,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1551,9 +1549,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "local-waker"
@@ -1572,9 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "matchers"
@@ -1599,9 +1597,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "mime"
@@ -1626,9 +1624,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -1657,9 +1655,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -1667,9 +1665,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -1821,16 +1819,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
+name = "pkg-config"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -1852,9 +1850,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -1927,9 +1925,9 @@ checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -2041,9 +2039,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -2053,18 +2051,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -2184,9 +2182,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2254,6 +2252,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2276,7 +2283,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -2308,9 +2315,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2323,6 +2330,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2330,9 +2353,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
@@ -2346,9 +2369,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2395,9 +2418,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2436,31 +2459,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2485,12 +2488,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -2500,15 +2502,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2516,9 +2518,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2551,7 +2553,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2589,6 +2591,45 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -2739,9 +2780,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-xid"
@@ -2818,9 +2859,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
@@ -2940,12 +2981,55 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tower",
  "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "webfinger-service"
+version = "0.0.32"
+dependencies = [
+ "serde",
+ "thiserror",
+ "toml",
+ "webfinger-rs",
+]
+
+[[package]]
+name = "webfinger-service-axum"
+version = "0.0.32"
+dependencies = [
+ "axum",
+ "clap",
+ "http 1.4.2",
+ "serde_json",
+ "tokio",
+ "tower",
+ "tower-http 0.7.0",
+ "tracing",
+ "tracing-subscriber",
+ "webfinger-rs",
+ "webfinger-service",
+]
+
+[[package]]
+name = "webfinger-service-worker"
+version = "0.0.32"
+dependencies = [
+ "axum",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "tracing-web",
+ "webfinger-rs",
+ "webfinger-service",
+ "worker",
 ]
 
 [[package]]
@@ -2957,7 +3041,7 @@ dependencies = [
  "http 1.4.2",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2970,9 +3054,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3047,20 +3131,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3074,40 +3149,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3117,21 +3171,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3147,21 +3189,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3171,27 +3201,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
@@ -3204,9 +3228,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "worker"
@@ -3215,6 +3239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f8adbf6c9ae45b665dee995c5e3a342c2bd7d58a2e8ca5c75b50ce8b1b8bfd9"
 dependencies = [
  "async-trait",
+ "axum",
  "bytes",
  "chrono",
  "futures-channel",
@@ -3269,9 +3294,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x509-parser"
@@ -3287,7 +3312,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
 ]
 
@@ -3309,9 +3334,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3320,9 +3345,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3332,18 +3357,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3353,15 +3378,15 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3370,9 +3395,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3381,9 +3406,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,13 @@
 [workspace]
 resolver = "2"
-members = ["webfinger-cli", "webfinger-rs", "webfinger-viewer-worker"]
+members = [
+    "webfinger-cli",
+    "webfinger-service-axum",
+    "webfinger-service-worker",
+    "webfinger-rs",
+    "webfinger-service",
+    "webfinger-viewer-worker",
+]
 
 [workspace.package]
 authors = ["Josh McKinney"]
@@ -36,13 +43,17 @@ serde = { version = "1.0.220", default-features = false, features = ["derive", "
 serde_json = { version = "1.0.140", default-features = false, features = ["std"] }
 serde_with = { version = "3", default-features = false, features = ["macros", "std"] }
 thiserror = { version = "2", default-features = false, features = ["std"] }
+toml = { version = "0.9", default-features = false, features = ["parse", "serde", "std"] }
 tokio = { version = "1.41", default-features = false }
 tower = "0.5.2"
 tower-http = { version = "0.7.0" }
+tower-service = "0.3"
 tracing = { version = "0.1.37", default-features = false, features = ["attributes", "std"] }
 tracing-subscriber = { version = "0.3.15", default-features = false, features = ["ansi", "env-filter", "fmt"] }
 tracing-web = "0.1.3"
 url = "2.5"
 web-sys = { version = "0.3.102", features = ["Response"] }
 webfinger-rs = { path = "webfinger-rs", version = "0.0.32" }
+webfinger-service = { path = "webfinger-service", version = "0.0.32", default-features = false }
+webfinger-service-axum = { path = "webfinger-service-axum", version = "0.0.32" }
 worker = { version = "0.8.5", default-features = false }

--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ Current integration targets:
 
 ## Repository tools
 
+This repository also contains a configurable WebFinger responder split across three crates:
+
+- [`webfinger-service`](webfinger-service/README.md) is the runtime-neutral core. It parses TOML
+  configuration, owns provider traits, and resolves exact WebFinger resources with `rel` filtering.
+- [`webfinger-service-axum`](webfinger-service-axum/README.md) is the native Axum server for local
+  development and non-Worker deployments.
+- [`webfinger-service-worker`](webfinger-service-worker/README.md) is the Cloudflare Worker
+  adapter. It reads TOML configuration from Workers KV and serves `/.well-known/webfinger`.
+
 This repository also contains `webfinger-viewer-worker`, a separate Rust Cloudflare Worker that
 serves a browser UI for inspecting WebFinger discovery behavior. It is a debugging tool, not the
 server-side WebFinger responder: the page accepts an `acct:` resource or full WebFinger URL, asks
@@ -160,6 +169,12 @@ async fn example() -> Result<(), Box<dyn std::error::Error>> {
 - Runnable example servers:
   `cargo run -p webfinger-rs --example axum --features axum`
   `cargo run -p webfinger-rs --example actix --features actix`
+- Deployable WebFinger service Worker:
+  [`webfinger-service-worker`](webfinger-service-worker/README.md)
+- Configurable native WebFinger service:
+  [`webfinger-service-axum`](webfinger-service-axum/README.md)
+- Runtime-neutral WebFinger service core:
+  [`webfinger-service`](webfinger-service/README.md)
 - Runnable example client:
   `cargo run -p webfinger-rs --example client --features reqwest`
 - CLI crate: [`webfinger-cli`](https://crates.io/crates/webfinger-cli)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "webfinger-viewer-worker",
+  "name": "webfinger-service-worker",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "webfinger-viewer-worker",
+      "name": "webfinger-service-worker",
       "version": "0.0.0",
       "dependencies": {
         "htmx.org": "2.0.10"
@@ -16,8 +16,6 @@
     },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
-      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "engines": {
@@ -26,8 +24,6 @@
     },
     "node_modules/@cloudflare/unenv-preset": {
       "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
-      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "peerDependencies": {
@@ -59,8 +55,6 @@
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
       "version": "1.20260701.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260701.1.tgz",
-      "integrity": "sha512-yBLsjS1qCWqFyCY37qRUrYfzHHvMGvjh8zRKJ6MvUivYDhkZTzqduppK38FoqYvayLJ5KbcxH7zo5rkxGqbsaA==",
       "cpu": [
         "arm64"
       ],
@@ -127,8 +121,6 @@
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -139,9 +131,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -219,8 +211,6 @@
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
-      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -593,8 +583,6 @@
     },
     "node_modules/@img/colour": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
-      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -603,8 +591,6 @@
     },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
       "cpu": [
         "arm64"
       ],
@@ -649,8 +635,6 @@
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
       "cpu": [
         "arm64"
       ],
@@ -1131,8 +1115,6 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1141,15 +1123,11 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1159,8 +1137,6 @@
     },
     "node_modules/@poppinss/colors": {
       "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
-      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1169,8 +1145,6 @@
     },
     "node_modules/@poppinss/dumper": {
       "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
-      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1181,15 +1155,11 @@
     },
     "node_modules/@poppinss/exception": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
-      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
-      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1201,22 +1171,16 @@
     },
     "node_modules/@speed-highlight/core": {
       "version": "1.2.17",
-      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
-      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
       "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
-      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1229,8 +1193,6 @@
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1239,8 +1201,6 @@
     },
     "node_modules/error-stack-parser-es": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
-      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1249,8 +1209,6 @@
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
-      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1312,8 +1270,6 @@
     },
     "node_modules/kleur": {
       "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1322,8 +1278,6 @@
     },
     "node_modules/miniflare": {
       "version": "4.20260701.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260701.0.tgz",
-      "integrity": "sha512-L6eAAi6IKtyb/7J6L+YsH2vb1yBrJWKRXI293JYDiMl70+6nncdAgigex58w6WBd+CwvdMsqOyNyGs95Op5gWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1343,22 +1297,16 @@
     },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1370,8 +1318,6 @@
     },
     "node_modules/sharp": {
       "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1415,8 +1361,6 @@
     },
     "node_modules/supports-color": {
       "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
-      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1436,8 +1380,6 @@
     },
     "node_modules/undici": {
       "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1446,8 +1388,6 @@
     },
     "node_modules/unenv": {
       "version": "2.0.0-rc.24",
-      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
-      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1456,8 +1396,6 @@
     },
     "node_modules/workerd": {
       "version": "1.20260701.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260701.1.tgz",
-      "integrity": "sha512-uF813NG09JwNRRUfJ0zBomyTslSPM810dMj9LVvkQ7RAkLrQLzAlPU8Xh/3dIqZDo2bfd7tChbf2PtqLRARRJQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1477,8 +1415,6 @@
     },
     "node_modules/wrangler": {
       "version": "4.107.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.107.0.tgz",
-      "integrity": "sha512-fw69ThymNitZ0oIEBU2yNeq3kK59UKz/jyA3udwRrQIAIsxX57q5qLOpPTN7qc5t8n9pnUeofe0uxtMuhQZW8w==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -1513,8 +1449,6 @@
     },
     "node_modules/ws": {
       "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1535,8 +1469,6 @@
     },
     "node_modules/youch": {
       "version": "4.1.0-beta.10",
-      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
-      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1549,8 +1481,6 @@
     },
     "node_modules/youch-core": {
       "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
-      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,17 @@
 {
-  "name": "webfinger-viewer-worker",
+  "name": "webfinger-service-worker",
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "deploy": "wrangler deploy",
-    "deploy:dry-run": "wrangler deploy --dry-run",
-    "dev": "wrangler dev"
+    "deploy": "npm run deploy:service",
+    "deploy:dry-run": "npm run deploy:service:dry-run",
+    "dev": "npm run dev:service",
+    "deploy:service": "wrangler deploy",
+    "deploy:service:dry-run": "wrangler deploy --dry-run",
+    "dev:service": "wrangler dev",
+    "deploy:viewer": "wrangler deploy --config wrangler.viewer.toml",
+    "deploy:viewer:dry-run": "wrangler deploy --config wrangler.viewer.toml --dry-run",
+    "dev:viewer": "wrangler dev --config wrangler.viewer.toml"
   },
   "devDependencies": {
     "wrangler": "^4.107.0"

--- a/scripts/build-webfinger-service-worker.sh
+++ b/scripts/build-webfinger-service-worker.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+set -eu
+
+# Cloudflare's dashboard/Git deploy image can start as a Node-only environment. Local developers
+# usually already have Rust, so keep this bootstrap conditional and let existing toolchains win.
+if ! command -v cargo >/dev/null 2>&1; then
+    if ! command -v curl >/dev/null 2>&1; then
+        echo "cargo is missing and curl is unavailable, so Rust cannot be bootstrapped" >&2
+        exit 1
+    fi
+
+    rustup_installer="$(mktemp)"
+    trap 'rm -f "$rustup_installer"' EXIT HUP INT TERM
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o "$rustup_installer"
+    sh "$rustup_installer" -y --profile minimal --default-toolchain stable
+
+    # rustup writes cargo's environment hook here for non-interactive installs.
+    # shellcheck disable=SC1090
+    . "${CARGO_HOME:-"$HOME/.cargo"}/env"
+fi
+
+# The service compiles to Wasm. This explicit add handles fresh Cloudflare build images.
+if command -v rustup >/dev/null 2>&1; then
+    rustup target add wasm32-unknown-unknown
+else
+    echo "rustup is unavailable; assuming wasm32-unknown-unknown is already installed" >&2
+fi
+
+worker_build_version="0.8.5"
+if ! command -v worker-build >/dev/null 2>&1 ||
+    [ "$(worker-build --version)" != "$worker_build_version" ]; then
+    cargo install -q worker-build --version "$worker_build_version"
+fi
+
+cd webfinger-service-worker
+worker-build --release

--- a/webfinger-service-axum/Cargo.toml
+++ b/webfinger-service-axum/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "webfinger-service-axum"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "A native Axum server for WebFinger service configuration."
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+readme = "README.md"
+keywords = ["webfinger", "service", "axum", "rust"]
+
+[dependencies]
+axum = { workspace = true, features = ["json", "http1", "tokio"] }
+clap = { workspace = true, features = ["derive", "env", "wrap_help"] }
+tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread"] }
+tower.workspace = true
+tower-http = { workspace = true, features = ["trace"] }
+tracing.workspace = true
+tracing-subscriber.workspace = true
+webfinger-rs = { workspace = true, features = ["axum"] }
+webfinger-service.workspace = true
+
+[dev-dependencies]
+http.workspace = true
+serde_json.workspace = true

--- a/webfinger-service-axum/README.md
+++ b/webfinger-service-axum/README.md
@@ -1,0 +1,56 @@
+# WebFinger Service Axum
+
+`webfinger-service-axum` is the native Axum server for `webfinger-service`. It owns Axum request
+extraction, response mapping, Tower HTTP tracing, and the local development binary.
+
+## Run Locally
+
+```console
+cargo run -p webfinger-service-axum
+```
+
+By default this reads `webfinger-service/webfinger.toml`, an empty config with no WebFinger
+responses, and listens on `127.0.0.1:8788`. Lookups return `404` until you point the server at a
+config file with resources.
+
+```console
+cargo run -p webfinger-service-axum -- --example-config --port 8790
+curl 'http://127.0.0.1:8790/.well-known/webfinger?resource=acct:alice@example.com'
+```
+
+The CLI also accepts environment variables:
+
+```console
+WEBFINGER_CONFIG_FILE=webfinger-service/webfinger.example.toml \
+  PORT=8790 \
+  cargo run -p webfinger-service-axum
+```
+
+Useful options:
+
+- `--config <PATH>` or `WEBFINGER_CONFIG_FILE` chooses a TOML config file.
+- `--example-config` serves `webfinger-service/webfinger.example.toml`.
+- `--host <HOST>` or `HOST` chooses the bind host.
+- `--port <PORT>` or `PORT` chooses the bind port.
+
+If the selected config path cannot be read, the process exits with a message that names the path. If
+the bind address is already in use, the process names the address and suggests changing `PORT` or
+stopping the process that owns the port.
+
+## Observability
+
+The Axum runtime installs compact `tracing-subscriber` output and a Tower HTTP trace layer. A plain
+`cargo run -p webfinger-service-axum` prints the bind address, and it prints request and response
+lines when the log filter allows `info` events. Set `RUST_LOG` to tune native logs:
+
+```console
+RUST_LOG=webfinger_service_axum=debug,tower_http=debug cargo run -p webfinger-service-axum
+```
+
+Useful log events include:
+
+- `webfinger service request` with `method`, `path`, and a stable `outcome` value.
+- provider and configuration errors at error level.
+
+When `RUST_LOG` is unset, the server defaults to `info`. Set `RUST_LOG` to any standard
+`tracing-subscriber` filter to tune or silence logs.

--- a/webfinger-service-axum/src/lib.rs
+++ b/webfinger-service-axum/src/lib.rs
@@ -1,0 +1,150 @@
+//! Native Axum adapter for `webfinger-service`.
+//!
+//! This crate turns a [`webfinger_service::StaticConfigProvider`] into an Axum router that serves
+//! the WebFinger endpoint at `/.well-known/webfinger`. It is intended for local development,
+//! simple native deployments, and tests that need the same HTTP mapping as the Cloudflare Worker
+//! without running Wrangler.
+//!
+//! The router accepts only `GET /.well-known/webfinger`, plus `GET /health` for local health
+//! checks. It maps malformed WebFinger queries to `400`, unknown resources to `404`, unsupported
+//! methods to `405`, and successful responses to `application/jrd+json`.
+
+use std::convert::Infallible;
+
+use axum::body::Body;
+use axum::extract::FromRequestParts;
+use axum::http::{Method, Request, StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use tower::service_fn;
+use tower_http::trace::{DefaultMakeSpan, DefaultOnRequest, DefaultOnResponse, TraceLayer};
+use tracing::{Level, info};
+use webfinger_rs::{WELL_KNOWN_PATH, WebFingerRequest};
+use webfinger_service::StaticConfigProvider;
+
+/// Builds a native Axum router for a static configuration provider.
+///
+/// The returned router uses a fallback service so it can make method and path decisions in one
+/// place. It also installs a Tower HTTP trace layer; configure `tracing-subscriber` in the binary
+/// or test harness to see request and response logs.
+pub fn axum_router(provider: StaticConfigProvider) -> axum::Router {
+    axum::Router::new()
+        .fallback_service(service_fn(move |request: Request<Body>| {
+            let provider = provider.clone();
+            async move {
+                let response = serve_static_http(provider, request).await;
+                Ok::<_, Infallible>(response)
+            }
+        }))
+        .layer(
+            TraceLayer::new_for_http()
+                .make_span_with(DefaultMakeSpan::new().level(Level::INFO))
+                .on_request(DefaultOnRequest::new().level(Level::INFO))
+                .on_response(DefaultOnResponse::new().level(Level::INFO)),
+        )
+}
+
+async fn serve_static_http<B>(provider: StaticConfigProvider, request: Request<B>) -> Response {
+    let method = request.method().clone();
+    let path = request.uri().path().to_string();
+    if method != Method::GET {
+        log_webfinger_request(&method, &path, "method_not_allowed");
+        return (
+            StatusCode::METHOD_NOT_ALLOWED,
+            [(header::ALLOW, Method::GET.as_str())],
+            "method not allowed",
+        )
+            .into_response();
+    }
+    if path == "/health" {
+        log_webfinger_request(&method, &path, "health");
+        return "OK".into_response();
+    }
+    if path != WELL_KNOWN_PATH {
+        log_webfinger_request(&method, &path, "not_found");
+        return (StatusCode::NOT_FOUND, "not found").into_response();
+    }
+
+    let (mut parts, _body) = request.into_parts();
+    let request = match WebFingerRequest::from_request_parts(&mut parts, &()).await {
+        Ok(request) => {
+            log_webfinger_request(&method, &path, "lookup");
+            request
+        }
+        Err(rejection) => {
+            log_webfinger_request(&method, &path, "bad_request");
+            return rejection.into_response();
+        }
+    };
+    match provider.resolve_config(&request) {
+        Some(response) => response.into_response(),
+        None => (StatusCode::NOT_FOUND, "resource not found").into_response(),
+    }
+}
+
+fn log_webfinger_request(method: &Method, path: &str, outcome: &str) {
+    info!(method = %method, path, outcome, "webfinger service request");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+    use axum::http::header;
+    use http::Request;
+    use webfinger_rs::WebFingerResponse;
+    use webfinger_service::EXAMPLE_CONFIG;
+
+    #[tokio::test]
+    async fn maps_unknown_resource_to_not_found() {
+        let response = call("/.well-known/webfinger?resource=acct:bob@example.com").await;
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn maps_unsupported_method_to_method_not_allowed() {
+        let provider = StaticConfigProvider::from_toml(EXAMPLE_CONFIG).unwrap();
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/.well-known/webfinger?resource=acct:alice@example.com")
+            .header("host", "example.com")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = serve_static_http(provider, request).await;
+
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+        assert_eq!(response.headers().get(header::ALLOW).unwrap(), "GET");
+    }
+
+    #[tokio::test]
+    async fn maps_malformed_query_to_bad_request() {
+        let response = call("/.well-known/webfinger").await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn successful_response_uses_jrd_content_type() {
+        let response = call("/.well-known/webfinger?resource=acct:alice@example.com").await;
+        let content_type = response.headers().get(http::header::CONTENT_TYPE).unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(content_type, "application/jrd+json");
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let response: WebFingerResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(response.subject.as_ref(), "acct:alice@example.com");
+    }
+
+    async fn call(uri: &str) -> axum::response::Response {
+        let provider = StaticConfigProvider::from_toml(EXAMPLE_CONFIG).unwrap();
+        let request = Request::builder()
+            .uri(uri)
+            .header("host", "example.com")
+            .body(Body::empty())
+            .unwrap();
+
+        serve_static_http(provider, request).await
+    }
+}

--- a/webfinger-service-axum/src/main.rs
+++ b/webfinger-service-axum/src/main.rs
@@ -1,0 +1,155 @@
+use std::path::{Path, PathBuf};
+
+use clap::Parser;
+
+const DEFAULT_CONFIG_FILE: &str = "webfinger-service/webfinger.toml";
+const EXAMPLE_CONFIG_FILE: &str = "webfinger-service/webfinger.example.toml";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use std::net::SocketAddr;
+
+    use tracing::info;
+    use webfinger_service::StaticConfigProvider;
+    use webfinger_service_axum::axum_router;
+
+    let _ = tracing_subscriber::fmt()
+        .compact()
+        .with_target(false)
+        .with_env_filter(log_filter())
+        .try_init();
+
+    let args = Args::parse();
+    let config_path = args.config_path();
+    let config = read_config(config_path)?;
+    let provider = StaticConfigProvider::from_toml(&config)?;
+
+    let addr: SocketAddr = format!("{}:{}", args.host, args.port).parse()?;
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .map_err(|error| bind_error(addr, error))?;
+
+    eprintln!(
+        "serving webfinger service at http://{addr}/.well-known/webfinger using {}",
+        config_path.display()
+    );
+    info!(%addr, config = %config_path.display(), "serving webfinger service");
+    axum::serve(listener, axum_router(provider)).await?;
+    Ok(())
+}
+
+#[derive(Debug, Parser)]
+#[command(author, version, about)]
+struct Args {
+    /// Configuration TOML file to serve.
+    #[arg(
+        long,
+        env = "WEBFINGER_CONFIG_FILE",
+        value_name = "PATH",
+        default_value = DEFAULT_CONFIG_FILE
+    )]
+    config: PathBuf,
+
+    /// Serve the bundled example configuration instead of the default empty config.
+    #[arg(long)]
+    example_config: bool,
+
+    /// Host address to bind.
+    #[arg(long, env = "HOST", default_value = "127.0.0.1")]
+    host: String,
+
+    /// TCP port to bind.
+    #[arg(long, env = "PORT", default_value_t = 8788)]
+    port: u16,
+}
+
+impl Args {
+    fn config_path(&self) -> &Path {
+        if self.example_config {
+            Path::new(EXAMPLE_CONFIG_FILE)
+        } else {
+            &self.config
+        }
+    }
+}
+
+fn read_config(path: &Path) -> Result<String, CliError> {
+    std::fs::read_to_string(path).map_err(|error| {
+        CliError(format!(
+            "could not read WebFinger config from {}: {error}",
+            path.display()
+        ))
+    })
+}
+
+fn bind_error(addr: std::net::SocketAddr, error: std::io::Error) -> CliError {
+    if error.kind() == std::io::ErrorKind::AddrInUse {
+        CliError(format!(
+            "could not start webfinger-service-axum because {addr} is already in use; \
+             stop the process using that port or run with PORT=<free-port>"
+        ))
+    } else {
+        CliError(format!(
+            "could not bind webfinger-service-axum to {addr}: {error}"
+        ))
+    }
+}
+
+struct CliError(String);
+
+impl std::fmt::Debug for CliError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::fmt::Display for CliError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for CliError {}
+
+fn log_filter() -> tracing_subscriber::EnvFilter {
+    tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn addr_in_use_error_names_address_and_fix() {
+        let addr = "127.0.0.1:8787".parse().unwrap();
+        let error = bind_error(
+            addr,
+            std::io::Error::new(std::io::ErrorKind::AddrInUse, "in use"),
+        );
+
+        let message = error.to_string();
+        assert!(message.contains("127.0.0.1:8787"));
+        assert!(message.contains("PORT=<free-port>"));
+    }
+
+    #[test]
+    fn empty_default_config_parses() {
+        webfinger_service::StaticConfigProvider::from_toml(include_str!(
+            "../../webfinger-service/webfinger.toml"
+        ))
+        .unwrap();
+    }
+
+    #[test]
+    fn example_config_flag_selects_example_file() {
+        let args = Args {
+            config: DEFAULT_CONFIG_FILE.into(),
+            example_config: true,
+            host: "127.0.0.1".to_string(),
+            port: 8788,
+        };
+
+        assert_eq!(args.config_path(), Path::new(EXAMPLE_CONFIG_FILE));
+    }
+}

--- a/webfinger-service-worker/Cargo.toml
+++ b/webfinger-service-worker/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "webfinger-service-worker"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "A Rust Cloudflare Worker for serving WebFinger service responses from KV-backed configuration."
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+readme = "README.md"
+keywords = ["webfinger", "cloudflare", "worker", "rust"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+axum.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+tracing-web.workspace = true
+webfinger-rs = { workspace = true, features = ["axum"] }
+webfinger-service.workspace = true
+worker = { workspace = true, features = ["http", "axum"] }
+
+[dev-dependencies]
+serde_json.workspace = true
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/webfinger-service-worker/README.md
+++ b/webfinger-service-worker/README.md
@@ -1,0 +1,107 @@
+# WebFinger Service Worker
+
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/joshka/webfinger-rs)
+
+`webfinger-service-worker` is a Rust Cloudflare Worker for serving WebFinger responses from
+configuration stored in Workers KV. It is meant for people who want a deployable WebFinger endpoint
+without writing their own server.
+
+## Deploy
+
+1. Click **Deploy to Cloudflare**.
+1. Choose a Worker name and complete the deploy flow.
+1. Open the created Workers KV namespace in the Cloudflare dashboard.
+1. Add a key named `webfinger.toml`.
+1. Paste the contents of [`webfinger.example.toml`](../webfinger-service/webfinger.example.toml) and
+   replace the example values.
+1. Add a Worker route for `example.com/.well-known/webfinger*`.
+1. Verify the endpoint:
+
+```console
+curl 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com'
+```
+
+The Worker reads KV binding `WEBFINGER_CONFIG` and key `webfinger.toml`.
+
+If the KV key is missing, the Worker returns a setup message instead of serving the bundled example
+identity. The example file is only a starting point for the value you paste into KV.
+
+## Configuration
+
+```toml
+[[resources]]
+resource = "acct:alice@example.com"
+aliases = [
+  "https://social.example/@alice",
+  "https://social.example/users/alice",
+]
+
+[[resources.links]]
+rel = "self"
+type = "application/activity+json"
+href = "https://social.example/users/alice"
+
+[[resources.links]]
+rel = "http://webfinger.net/rel/profile-page"
+type = "text/html"
+href = "https://social.example/@alice"
+
+[[resources.links]]
+rel = "http://ostatus.org/schema/1.0/subscribe"
+template = "https://social.example/authorize_interaction?uri={uri}"
+```
+
+The lookup key is the exact `resource` string. When a request includes `rel` parameters, the Worker
+returns only matching links.
+
+String-valued JRD properties can be written as normal TOML strings. To publish a JSON `null`
+property value, use `{ null = true }`.
+
+## Local Development
+
+Install dependencies and build the Worker:
+
+```console
+npm install
+npm run deploy:dry-run
+```
+
+The checked-in `wrangler.toml` build hook runs `scripts/build-webfinger-service-worker.sh`, which
+installs a minimal Rust toolchain only when `cargo` is missing, adds the Wasm target, and runs
+`worker-build`. Local developers with Rust already installed use their existing toolchain.
+
+Run locally:
+
+```console
+npm run dev
+```
+
+Seed KV from the CLI instead of the dashboard:
+
+```console
+npx wrangler kv key put webfinger.toml --binding WEBFINGER_CONFIG \
+  --path webfinger-service/webfinger.example.toml
+```
+
+Deploy after updating `wrangler.toml` or configuring the route in the Cloudflare dashboard:
+
+```console
+npm run deploy
+```
+
+## Observability
+
+`wrangler.toml` enables Cloudflare Worker observability. The Worker installs a console-backed
+`tracing` subscriber in wasm builds, so request decisions and provider failures appear in Wrangler
+tail and Cloudflare dashboard logs. Useful log events include:
+
+- `webfinger service request` with `method`, `path`, and a stable `outcome` value.
+- `resolved webfinger response` with the requested resource in the current tracing span.
+- KV binding, read, and configuration errors at error level.
+
+## Rust Extension Point
+
+Applications that need D1, remote fetch, Durable Objects, or another async source can implement
+`WebFingerProvider` and pass it to `Worker::new(provider).serve(request)` or
+`serve_with_provider(&provider, request)`. The Worker crate owns Cloudflare HTTP response mapping
+and wasm logging; `webfinger-service` owns the shared config and provider contracts.

--- a/webfinger-service-worker/src/kv.rs
+++ b/webfinger-service-worker/src/kv.rs
@@ -1,0 +1,88 @@
+use webfinger_rs::{WebFingerRequest, WebFingerResponse};
+use webfinger_service::{ProviderError, WEBFINGER_CONFIG_KEY, WebFingerProvider};
+use worker::Env;
+
+/// The default Workers KV binding name for WebFinger configuration.
+///
+/// Binding names are local to a Worker. Different Cloudflare accounts can use the same binding
+/// name while pointing at account-specific KV namespaces.
+pub const WEBFINGER_CONFIG_BINDING: &str = "WEBFINGER_CONFIG";
+
+/// A provider backed by TOML stored in Workers KV.
+///
+/// `KvConfigProvider` reads the configured KV key on each WebFinger lookup, parses the TOML into a
+/// [`webfinger_service::Config`], and resolves the request against that config. This keeps the
+/// Cloudflare dashboard KV editor as the source of truth: changing the `webfinger.toml` value
+/// updates future requests without rebuilding the Worker.
+///
+/// Use [`KvConfigProvider::from_env`] for the conventional `WEBFINGER_CONFIG` binding and
+/// `webfinger.toml` key. Use [`KvConfigProvider::from_env_binding`] when embedding this provider in
+/// a Worker with different binding or key names.
+#[derive(Clone)]
+pub struct KvConfigProvider {
+    kv: worker::kv::KvStore,
+    key: String,
+}
+
+impl std::fmt::Debug for KvConfigProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KvConfigProvider")
+            .field("key", &self.key)
+            .finish_non_exhaustive()
+    }
+}
+
+impl KvConfigProvider {
+    /// Creates a KV-backed provider from a Cloudflare Worker environment.
+    ///
+    /// This uses the documented `WEBFINGER_CONFIG` binding and `webfinger.toml` key.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProviderError::Binding`] if the Worker environment does not contain the expected
+    /// KV binding.
+    pub fn from_env(env: &Env) -> Result<Self, ProviderError> {
+        Self::from_env_binding(env, WEBFINGER_CONFIG_BINDING, WEBFINGER_CONFIG_KEY)
+    }
+
+    /// Creates a KV-backed provider from a named binding and key.
+    ///
+    /// This is useful for custom deployments that want to keep the provider behavior but use a
+    /// different binding name or config key.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProviderError::Binding`] if `binding` is not present in the Worker environment.
+    pub fn from_env_binding(env: &Env, binding: &str, key: &str) -> Result<Self, ProviderError> {
+        let kv = env.kv(binding).map_err(|source| ProviderError::Binding {
+            binding: binding.to_string(),
+            message: source.to_string(),
+        })?;
+        Ok(Self {
+            kv,
+            key: key.to_string(),
+        })
+    }
+}
+
+impl WebFingerProvider for KvConfigProvider {
+    async fn resolve<'a>(
+        &'a self,
+        request: &'a WebFingerRequest,
+    ) -> Result<Option<WebFingerResponse>, ProviderError> {
+        let input = self
+            .kv
+            .get(&self.key)
+            .text()
+            .await
+            .map_err(|source| ProviderError::ReadConfig {
+                key: self.key.clone(),
+                message: source.to_string(),
+            })?
+            .ok_or_else(|| ProviderError::MissingConfig {
+                key: self.key.clone(),
+            })?;
+        let config = webfinger_service::Config::from_toml(&input)?;
+        Ok(config.resolve(request))
+    }
+}

--- a/webfinger-service-worker/src/lib.rs
+++ b/webfinger-service-worker/src/lib.rs
@@ -1,0 +1,321 @@
+//! Cloudflare Worker runtime for serving WebFinger responses from editable KV configuration.
+//!
+//! Shared TOML parsing, provider traits, and relation filtering live in `webfinger-service`.
+//! This crate owns the Cloudflare Worker boundary: KV configuration, HTTP mapping, wasm logging,
+//! and the `fetch` entrypoint.
+//!
+//! The default Worker entrypoint reads TOML from Workers KV binding `WEBFINGER_CONFIG` and key
+//! `webfinger.toml`. Custom Workers can reuse the same HTTP mapping by constructing
+//! [`Worker::new`] with any [`webfinger_service::WebFingerProvider`] implementation or by calling
+//! [`serve_with_provider`].
+//!
+//! Public HTTP error bodies intentionally avoid detailed provider/configuration failures, except
+//! for the missing setup key message. Detailed failures are logged through `tracing` for Wrangler
+//! tail and Cloudflare Worker logs.
+
+mod kv;
+mod observability;
+
+use axum::extract::FromRequestParts;
+use axum::http::{Method, StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use thiserror::Error;
+use tracing::{error, info, instrument};
+use webfinger_rs::{WELL_KNOWN_PATH, WebFingerRequest, WebFingerResponse};
+use webfinger_service::{ProviderError, WebFingerProvider};
+use worker::{Context, Env, HttpRequest};
+
+pub use crate::kv::{KvConfigProvider, WEBFINGER_CONFIG_BINDING};
+
+/// A WebFinger Worker backed by a caller-provided provider.
+///
+/// Use this type when the data source is not the default Workers KV key. The provider owns
+/// resource lookup and relation filtering; the Worker owns method/path checks, WebFinger request
+/// extraction, response headers, status codes, and logging.
+#[derive(Debug, Clone)]
+pub struct Worker<P> {
+    provider: P,
+}
+
+impl<P> Worker<P> {
+    /// Creates a Worker from a provider.
+    pub fn new(provider: P) -> Self {
+        Self { provider }
+    }
+}
+
+impl<P> Worker<P>
+where
+    P: WebFingerProvider,
+{
+    /// Serves one HTTP request with this Worker's provider.
+    ///
+    /// This method is useful from custom `#[worker::event(fetch)]` functions after the caller has
+    /// constructed a provider from bindings or other Worker state.
+    pub async fn serve(&self, request: HttpRequest) -> Response {
+        serve_with_provider(&self.provider, request).await
+    }
+}
+
+/// Serves one Cloudflare Worker HTTP request using the default KV provider.
+///
+/// This is the function used by the bundled `fetch` entrypoint. It expects the Worker environment
+/// to contain KV binding [`WEBFINGER_CONFIG_BINDING`] and reads configuration from
+/// [`webfinger_service::WEBFINGER_CONFIG_KEY`].
+///
+/// # Errors
+///
+/// Returns a Worker error if the required KV binding is missing. Provider failures that happen
+/// after the binding is available are mapped into HTTP responses and logged.
+pub async fn serve(request: HttpRequest, env: Env, _ctx: Context) -> worker::Result<Response> {
+    let provider = KvConfigProvider::from_env(&env)
+        .map_err(|error| worker::Error::RustError(error.to_string()))?;
+    Ok(Worker::new(provider).serve(request).await)
+}
+
+/// Serves one HTTP request with a caller-provided WebFinger provider.
+///
+/// This is the lowest-level reusable HTTP mapping in the Worker crate. It accepts only
+/// `GET /.well-known/webfinger`, plus `GET /health`, and maps provider results into WebFinger HTTP
+/// responses. Use [`Worker`] when you want to hold a provider value and serve multiple requests
+/// through the same wrapper.
+pub async fn serve_with_provider<P>(provider: &P, request: HttpRequest) -> Response
+where
+    P: WebFingerProvider,
+{
+    let method = request.method().clone();
+    let path = request.uri().path().to_string();
+    if method != Method::GET {
+        log_webfinger_request(&method, &path, "method_not_allowed");
+        return (
+            StatusCode::METHOD_NOT_ALLOWED,
+            [(header::ALLOW, Method::GET.as_str())],
+            "method not allowed",
+        )
+            .into_response();
+    }
+    if path == "/health" {
+        log_webfinger_request(&method, &path, "health");
+        return "OK".into_response();
+    }
+    if path != WELL_KNOWN_PATH {
+        log_webfinger_request(&method, &path, "not_found");
+        return (StatusCode::NOT_FOUND, "not found").into_response();
+    }
+
+    let (mut parts, _body) = request.into_parts();
+    let request = match WebFingerRequest::from_request_parts(&mut parts, &()).await {
+        Ok(request) => {
+            log_webfinger_request(&method, &path, "lookup");
+            request
+        }
+        Err(rejection) => {
+            log_webfinger_request(&method, &path, "bad_request");
+            return rejection.into_response();
+        }
+    };
+    webfinger(provider, request).await.into_response()
+}
+
+#[instrument(skip(provider, request), fields(resource = %request.resource))]
+async fn webfinger<P>(
+    provider: &P,
+    request: WebFingerRequest,
+) -> Result<WebFingerResponse, HttpError>
+where
+    P: WebFingerProvider,
+{
+    match provider.resolve(&request).await? {
+        Some(response) => {
+            info!("resolved webfinger response");
+            Ok(response)
+        }
+        None => Err(HttpError::NotFound),
+    }
+}
+
+fn log_webfinger_request(method: &Method, path: &str, outcome: &str) {
+    info!(method = %method, path, outcome, "webfinger service request");
+}
+
+#[derive(Debug, Error)]
+enum HttpError {
+    #[error("resource not found")]
+    NotFound,
+
+    #[error(transparent)]
+    Provider(#[from] ProviderError),
+}
+
+impl IntoResponse for HttpError {
+    fn into_response(self) -> Response {
+        match self {
+            HttpError::NotFound => (StatusCode::NOT_FOUND, "resource not found").into_response(),
+            HttpError::Provider(error) => {
+                error!(?error, "webfinger provider failed");
+                let message = match error {
+                    ProviderError::MissingConfig { key } => format!(
+                        "WebFinger is not configured. Add TOML configuration to key `{key}`."
+                    ),
+                    _ => {
+                        "WebFinger provider failed. Check the Worker logs for details.".to_string()
+                    }
+                };
+                (StatusCode::INTERNAL_SERVER_ERROR, message).into_response()
+            }
+        }
+    }
+}
+
+/// Cloudflare Worker lifecycle entrypoint for logging setup.
+#[worker::event(start)]
+fn start() {
+    observability::init();
+}
+
+/// Cloudflare Worker fetch entrypoint.
+#[worker::event(fetch)]
+async fn fetch(request: HttpRequest, env: Env, ctx: Context) -> worker::Result<Response> {
+    observability::init();
+    serve(request, env, ctx).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+    use axum::http::{Request, header};
+    use webfinger_service::{EXAMPLE_CONFIG, StaticConfigProvider, WEBFINGER_CONFIG_KEY};
+    use worker::Body;
+
+    #[tokio::test]
+    async fn maps_unknown_resource_to_not_found() {
+        let response = call("/.well-known/webfinger?resource=acct:bob@example.com").await;
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn maps_unknown_path_to_not_found() {
+        let response = call("/").await;
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn maps_unsupported_method_to_method_not_allowed() {
+        let provider = StaticConfigProvider::from_toml(EXAMPLE_CONFIG).unwrap();
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/.well-known/webfinger?resource=acct:alice@example.com")
+            .header("host", "example.com")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = Worker::new(provider).serve(request).await;
+
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+        assert_eq!(response.headers().get(header::ALLOW).unwrap(), "GET");
+    }
+
+    #[tokio::test]
+    async fn maps_malformed_query_to_bad_request() {
+        let response = call("/.well-known/webfinger").await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn successful_response_uses_jrd_content_type() {
+        let response = call("/.well-known/webfinger?resource=acct:alice@example.com").await;
+        let content_type = response.headers().get(header::CONTENT_TYPE).unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(content_type, "application/jrd+json");
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let response: WebFingerResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(response.subject.as_ref(), "acct:alice@example.com");
+    }
+
+    #[tokio::test]
+    async fn missing_config_returns_setup_error() {
+        let request = Request::builder()
+            .uri("/.well-known/webfinger?resource=acct:alice@example.com")
+            .header("host", "example.com")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = Worker::new(MissingConfigProvider).serve(request).await;
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = String::from_utf8(body.to_vec()).unwrap();
+        assert!(body.contains(WEBFINGER_CONFIG_KEY));
+        assert!(body.contains("Add TOML configuration"));
+    }
+
+    #[tokio::test]
+    async fn provider_errors_do_not_expose_config_details() {
+        let request = Request::builder()
+            .uri("/.well-known/webfinger?resource=acct:alice@example.com")
+            .header("host", "example.com")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = Worker::new(InvalidConfigProvider).serve(request).await;
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = String::from_utf8(body.to_vec()).unwrap();
+        assert!(body.contains("Check the Worker logs"));
+        assert!(!body.contains("acct:alice@example.com"));
+    }
+
+    async fn call(uri: &str) -> Response {
+        let provider = StaticConfigProvider::from_toml(EXAMPLE_CONFIG).unwrap();
+        let request = Request::builder()
+            .uri(uri)
+            .header("host", "example.com")
+            .body(Body::empty())
+            .unwrap();
+
+        Worker::new(provider).serve(request).await
+    }
+
+    struct MissingConfigProvider;
+
+    impl WebFingerProvider for MissingConfigProvider {
+        async fn resolve<'a>(
+            &'a self,
+            _request: &'a WebFingerRequest,
+        ) -> Result<Option<WebFingerResponse>, ProviderError> {
+            Err(ProviderError::MissingConfig {
+                key: WEBFINGER_CONFIG_KEY.to_string(),
+            })
+        }
+    }
+
+    struct InvalidConfigProvider;
+
+    impl WebFingerProvider for InvalidConfigProvider {
+        async fn resolve<'a>(
+            &'a self,
+            _request: &'a WebFingerRequest,
+        ) -> Result<Option<WebFingerResponse>, ProviderError> {
+            Err(webfinger_service::Config::from_toml(
+                r#"
+[[resources]]
+resource = "acct:alice@example.com"
+
+[[resources]]
+resource = "acct:alice@example.com"
+"#,
+            )
+            .unwrap_err()
+            .into())
+        }
+    }
+}

--- a/webfinger-service-worker/src/observability.rs
+++ b/webfinger-service-worker/src/observability.rs
@@ -1,0 +1,30 @@
+//! Worker logging setup.
+//!
+//! Cloudflare Worker Logs capture messages written to the JavaScript console. The service uses
+//! `tracing` for request and provider breadcrumbs, so wasm builds install a console-backed tracing
+//! subscriber at the Worker boundary.
+
+/// Installs logging support for the current runtime.
+pub fn init() {
+    #[cfg(target_arch = "wasm32")]
+    init_wasm_console_tracing();
+}
+
+#[cfg(target_arch = "wasm32")]
+fn init_wasm_console_tracing() {
+    use std::sync::Once;
+    use tracing_subscriber::prelude::*;
+
+    static INIT: Once = Once::new();
+
+    INIT.call_once(|| {
+        let fmt_layer = tracing_subscriber::fmt::layer()
+            .with_ansi(false)
+            .without_time()
+            .with_writer(tracing_web::MakeWebConsoleWriter::new());
+
+        let subscriber = tracing_subscriber::registry().with(fmt_layer);
+
+        let _ = tracing::subscriber::set_global_default(subscriber);
+    });
+}

--- a/webfinger-service/Cargo.toml
+++ b/webfinger-service/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "webfinger-service"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "Runtime-neutral WebFinger service configuration and provider types."
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+readme = "README.md"
+keywords = ["webfinger", "service", "config", "rust"]
+
+[dependencies]
+serde.workspace = true
+thiserror.workspace = true
+toml.workspace = true
+webfinger-rs.workspace = true

--- a/webfinger-service/README.md
+++ b/webfinger-service/README.md
@@ -1,0 +1,136 @@
+# WebFinger Service
+
+`webfinger-service` is the runtime-neutral WebFinger responder core. It owns configuration parsing,
+provider traits, exact resource matching, and relation filtering.
+
+Runtime adapters live in separate crates:
+
+- `webfinger-service-axum` provides the native Axum server.
+- `webfinger-service-worker` provides the Cloudflare Worker.
+
+## Configuration
+
+The default empty config is [`webfinger.toml`](webfinger.toml):
+
+```toml
+resources = []
+```
+
+Use [`webfinger.example.toml`](webfinger.example.toml) as a starting point for a real responder:
+
+```toml
+[[resources]]
+resource = "acct:alice@example.com"
+
+[[resources.links]]
+rel = "self"
+type = "application/activity+json"
+href = "https://social.example/users/alice"
+```
+
+The lookup key is the exact `resource` string. If a request includes repeated `rel` parameters, the
+runtime adapters return only matching links.
+
+Supported TOML fields map directly to JRD fields:
+
+- resource-level: `resource`, `aliases`, `properties`.
+- link-level: `rel`, `type`, `href`, `template`, `titles`, `properties`.
+
+String-valued JRD properties can be written as normal TOML strings. To publish a JSON `null`
+property value, use `{ null = true }`.
+
+## Rust API
+
+Use `StaticConfigProvider` when the configuration is already loaded into memory:
+
+```rust
+use webfinger_rs::WebFingerRequest;
+use webfinger_service::{StaticConfigProvider, WebFingerProvider};
+
+async fn resolve_alice() -> Result<(), Box<dyn std::error::Error>> {
+    let provider = StaticConfigProvider::from_toml(
+        r#"
+[[resources]]
+resource = "acct:alice@example.com"
+
+[[resources.links]]
+rel = "self"
+type = "application/activity+json"
+href = "https://social.example/users/alice"
+"#,
+    )?;
+    let request = WebFingerRequest::builder("acct:alice@example.com")?
+        .host("example.com")
+        .build();
+
+    let response = provider.resolve(&request).await?.unwrap();
+
+    assert_eq!(response.subject.as_ref(), "acct:alice@example.com");
+    Ok(())
+}
+```
+
+## Extension Point
+
+`WebFingerProvider` is the async boundary between runtime adapters and responder data. Implement it
+when responses come from a database, Workers KV, D1, a remote fetch, Durable Objects, or another
+source that cannot be loaded into `StaticConfigProvider`.
+
+A provider receives a parsed `WebFingerRequest` and returns one domain result:
+
+- `Ok(Some(response))` when the requested resource is known.
+- `Ok(None)` when the request is valid but the resource is unknown.
+- `Err(error)` when configuration, storage, or provider logic failed.
+
+Providers own exact resource lookup and `rel` filtering. If `request.rels` is not empty, return only
+links whose `rel` is present in that list. Runtime adapters own HTTP status codes, logging, and
+response headers.
+
+```rust
+use std::collections::BTreeMap;
+
+use webfinger_rs::{Link, Rel, WebFingerRequest, WebFingerResponse};
+use webfinger_service::{ProviderError, WebFingerProvider};
+
+#[derive(Default)]
+struct DirectoryProvider {
+    resources: BTreeMap<String, WebFingerResponse>,
+}
+
+impl WebFingerProvider for DirectoryProvider {
+    async fn resolve<'a>(
+        &'a self,
+        request: &'a WebFingerRequest,
+    ) -> Result<Option<WebFingerResponse>, ProviderError> {
+        let Some(response) = self.resources.get(request.resource.as_ref()) else {
+            return Ok(None);
+        };
+
+        let mut response = response.clone();
+        if !request.rels.is_empty() {
+            response.links.retain(|link| request.rels.contains(&link.rel));
+        }
+        Ok(Some(response))
+    }
+}
+
+async fn lookup() -> Result<(), Box<dyn std::error::Error>> {
+    let mut provider = DirectoryProvider::default();
+    let response = WebFingerResponse::try_builder("acct:alice@example.com")?
+        .link(Link::builder(Rel::new("self")).href("https://social.example/users/alice"))
+        .build();
+    provider
+        .resources
+        .insert(response.subject.to_string(), response);
+
+    let request = WebFingerRequest::builder("acct:alice@example.com")?
+        .host("example.com")
+        .rel("self")
+        .build();
+
+    let response = provider.resolve(&request).await?.unwrap();
+
+    assert_eq!(response.links.len(), 1);
+    Ok(())
+}
+```

--- a/webfinger-service/src/config.rs
+++ b/webfinger-service/src/config.rs
@@ -1,0 +1,183 @@
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+use thiserror::Error;
+use webfinger_rs::{JrdUri, Link, Rel, WebFingerRequest, WebFingerResponse};
+
+/// WebFinger resources loaded from TOML configuration.
+///
+/// `Config` is the in-memory representation used by [`StaticConfigProvider`](crate::StaticConfigProvider)
+/// and by runtime providers that load TOML from another store before resolving a request.
+///
+/// Resources are keyed by their exact `resource` string. A request for
+/// `acct:alice@example.com` does not match `acct:Alice@example.com`, an alias URL, or any inferred
+/// account domain. Relation filtering is applied during resolution: when a request contains one or
+/// more `rel` parameters, the returned response contains only links with matching relation values.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Config {
+    resources: BTreeMap<String, WebFingerResponse>,
+}
+
+impl Config {
+    /// Parses WebFinger configuration from TOML.
+    ///
+    /// The top-level TOML document must contain a `resources` array. Each resource maps onto a JRD
+    /// response with supported resource-level fields `resource`, `aliases`, and `properties`, and
+    /// supported link-level fields `rel`, `type`, `href`, `template`, `titles`, and `properties`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError`] when the TOML is malformed, contains duplicate resource entries,
+    /// uses unsupported fields, uses an invalid WebFinger/JRD URI value, or uses the `{ null =
+    /// true }` property marker incorrectly.
+    pub fn from_toml(input: &str) -> Result<Self, ConfigError> {
+        let raw: RawConfig = toml::from_str(input)?;
+        let mut resources = BTreeMap::new();
+        for resource in raw.resources {
+            let response = resource.into_response()?;
+            let previous = resources.insert(response.subject.to_string(), response);
+            if let Some(previous) = previous {
+                return Err(ConfigError::DuplicateResource(previous.subject.to_string()));
+            }
+        }
+        Ok(Self { resources })
+    }
+
+    /// Resolves a request against the configured resources.
+    ///
+    /// Returns `None` when the requested resource is not present. Returned responses are cloned
+    /// from the config so relation filtering can remove links without mutating shared
+    /// configuration.
+    pub fn resolve(&self, request: &WebFingerRequest) -> Option<WebFingerResponse> {
+        let response = self.resources.get(request.resource.as_ref())?;
+        Some(filter_response(response.clone(), &request.rels))
+    }
+}
+
+fn filter_response(mut response: WebFingerResponse, rels: &[Rel]) -> WebFingerResponse {
+    if !rels.is_empty() {
+        response.links.retain(|link| rels.contains(&link.rel));
+    }
+    response
+}
+
+/// Errors raised while parsing WebFinger TOML configuration.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ConfigError {
+    /// The TOML was malformed.
+    #[error("invalid TOML configuration: {0}")]
+    Toml(#[from] toml::de::Error),
+
+    /// A configured resource appeared more than once.
+    #[error("duplicate resource `{0}`")]
+    DuplicateResource(String),
+
+    /// A configured resource or JRD URI field was invalid.
+    #[error(transparent)]
+    WebFinger(#[from] webfinger_rs::Error),
+
+    /// A configured property used the TOML null marker incorrectly.
+    #[error("property `{0}` uses invalid null marker; use `{{ null = true }}`")]
+    InvalidNullProperty(String),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawConfig {
+    resources: Vec<RawResource>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawResource {
+    resource: String,
+    aliases: Option<Vec<String>>,
+    properties: Option<BTreeMap<String, RawPropertyValue>>,
+    links: Option<Vec<RawLink>>,
+}
+
+impl RawResource {
+    fn into_response(self) -> Result<WebFingerResponse, ConfigError> {
+        let mut builder = WebFingerResponse::try_builder(&self.resource)?;
+        if let Some(aliases) = self.aliases {
+            for alias in aliases {
+                builder = builder.alias(alias);
+            }
+        }
+        if let Some(properties) = self.properties {
+            for (key, value) in properties {
+                builder = match value.into_option(&key)? {
+                    Some(value) => builder.property(key, value),
+                    None => builder.null_property(key),
+                };
+            }
+        }
+        if let Some(links) = self.links {
+            let links = links
+                .into_iter()
+                .map(RawLink::into_link)
+                .collect::<Result<Vec<_>, _>>()?;
+            builder = builder.links(links);
+        }
+        Ok(builder.build())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawLink {
+    rel: String,
+    r#type: Option<String>,
+    href: Option<String>,
+    template: Option<String>,
+    titles: Option<BTreeMap<String, String>>,
+    properties: Option<BTreeMap<String, RawPropertyValue>>,
+}
+
+impl RawLink {
+    fn into_link(self) -> Result<Link, ConfigError> {
+        let mut link = Link::new(Rel::try_new(self.rel)?);
+        link.r#type = self.r#type;
+        link.href = self.href.map(JrdUri::try_new).transpose()?;
+        link.template = self.template;
+        link.titles = self.titles;
+        link.properties = self.properties.map(parse_properties).transpose()?;
+        Ok(link)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum RawPropertyValue {
+    String(String),
+    Null { null: bool },
+}
+
+impl RawPropertyValue {
+    fn into_option(self, key: &str) -> Result<Option<String>, ConfigError> {
+        match self {
+            RawPropertyValue::String(value) => Ok(Some(value)),
+            RawPropertyValue::Null { null } => {
+                if null {
+                    Ok(None)
+                } else {
+                    Err(ConfigError::InvalidNullProperty(key.to_string()))
+                }
+            }
+        }
+    }
+}
+
+fn parse_properties(
+    properties: BTreeMap<String, RawPropertyValue>,
+) -> Result<BTreeMap<JrdUri, Option<String>>, ConfigError> {
+    properties
+        .into_iter()
+        .map(|(key, value)| {
+            let property = JrdUri::try_new(key)?;
+            let value = value.into_option(property.as_ref())?;
+            Ok((property, value))
+        })
+        .collect()
+}

--- a/webfinger-service/src/lib.rs
+++ b/webfinger-service/src/lib.rs
@@ -1,0 +1,58 @@
+//! Shared WebFinger responder runtime.
+//!
+//! This crate owns the runtime-neutral WebFinger responder behavior: TOML configuration parsing,
+//! provider traits, and relation filtering. Native Axum support lives in
+//! `webfinger-service-axum`. Cloudflare-specific KV and Worker entrypoints live in
+//! `webfinger-service-worker`.
+//!
+//! # Example
+//!
+//! ```
+//! use webfinger_rs::WebFingerRequest;
+//! use webfinger_service::{StaticConfigProvider, WebFingerProvider};
+//!
+//! # async fn resolve_alice() -> Result<(), Box<dyn std::error::Error>> {
+//! let provider = StaticConfigProvider::from_toml(
+//!     r#"
+//! [[resources]]
+//! resource = "acct:alice@example.com"
+//!
+//! [[resources.links]]
+//! rel = "self"
+//! type = "application/activity+json"
+//! href = "https://social.example/users/alice"
+//! "#,
+//! )?;
+//! let request = WebFingerRequest::builder("acct:alice@example.com")?
+//!     .host("example.com")
+//!     .build();
+//!
+//! let response = provider.resolve(&request).await?.unwrap();
+//!
+//! assert_eq!(response.subject.as_ref(), "acct:alice@example.com");
+//! assert_eq!(response.links.len(), 1);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Provider Model
+//!
+//! [`WebFingerProvider`] is the async extension point used by runtime adapters. Implement it when
+//! WebFinger responses come from a database, Workers KV, a remote service, or another source that
+//! cannot be represented as static TOML. Providers own exact resource lookup and `rel` filtering;
+//! adapters own HTTP status codes, response headers, and logging.
+
+mod config;
+mod provider;
+
+#[cfg(test)]
+mod tests;
+
+pub use crate::config::{Config, ConfigError};
+pub use crate::provider::{ProviderError, StaticConfigProvider, WebFingerProvider};
+
+/// The default configuration key used by deployable runtimes.
+pub const WEBFINGER_CONFIG_KEY: &str = "webfinger.toml";
+
+/// An example configuration suitable for the first value a user edits.
+pub const EXAMPLE_CONFIG: &str = include_str!("../webfinger.example.toml");

--- a/webfinger-service/src/provider.rs
+++ b/webfinger-service/src/provider.rs
@@ -1,0 +1,163 @@
+use std::future::Future;
+
+use thiserror::Error;
+use webfinger_rs::{WebFingerRequest, WebFingerResponse};
+
+use crate::{Config, ConfigError};
+
+/// Resolves a WebFinger request into an optional JRD response.
+///
+/// Providers are the data boundary for a WebFinger service. A provider may read from static
+/// configuration, Workers KV, D1, a database, a remote fetch, a Durable Object, or any other source
+/// that can answer a [`WebFingerRequest`].
+///
+/// The provider owns resource lookup and relation filtering:
+///
+/// - Return `Ok(Some(response))` when the requested `resource` is known.
+/// - Return `Ok(None)` when the request is valid but the resource is unknown.
+/// - Return `Err(error)` when the backing store, configuration, or provider logic failed.
+/// - If `request.rels` is not empty, return only links whose `rel` is present in that list.
+///
+/// Runtime adapters such as `webfinger-service-axum` and `webfinger-service-worker` own HTTP status
+/// codes, response headers, and logging. Providers should return domain results rather than HTTP
+/// responses.
+///
+/// # Examples
+///
+/// ```
+/// use std::collections::BTreeMap;
+///
+/// use webfinger_rs::{Link, Rel, WebFingerRequest, WebFingerResponse};
+/// use webfinger_service::{ProviderError, WebFingerProvider};
+///
+/// #[derive(Default)]
+/// struct DirectoryProvider {
+///     resources: BTreeMap<String, WebFingerResponse>,
+/// }
+///
+/// impl WebFingerProvider for DirectoryProvider {
+///     async fn resolve<'a>(
+///         &'a self,
+///         request: &'a WebFingerRequest,
+///     ) -> Result<Option<WebFingerResponse>, ProviderError> {
+///         let Some(response) = self.resources.get(request.resource.as_ref()) else {
+///             return Ok(None);
+///         };
+///
+///         let mut response = response.clone();
+///         if !request.rels.is_empty() {
+///             response.links.retain(|link| request.rels.contains(&link.rel));
+///         }
+///         Ok(Some(response))
+///     }
+/// }
+///
+/// # async fn lookup() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut provider = DirectoryProvider::default();
+/// let response = WebFingerResponse::try_builder("acct:alice@example.com")?
+///     .link(Link::builder(Rel::new("self")).href("https://social.example/users/alice"))
+///     .build();
+/// provider
+///     .resources
+///     .insert(response.subject.to_string(), response);
+///
+/// let request = WebFingerRequest::builder("acct:alice@example.com")?
+///     .host("example.com")
+///     .rel("self")
+///     .build();
+///
+/// let response = provider.resolve(&request).await?.unwrap();
+/// assert_eq!(response.links.len(), 1);
+/// # Ok(())
+/// # }
+/// ```
+pub trait WebFingerProvider {
+    /// Resolves a WebFinger request.
+    ///
+    /// Implementations may perform asynchronous I/O. Use the `request.resource` value for exact
+    /// resource lookup and `request.rels` for relation filtering. Return `Ok(None)` for a valid
+    /// request whose resource is not configured or otherwise unknown.
+    fn resolve<'a>(
+        &'a self,
+        request: &'a WebFingerRequest,
+    ) -> impl Future<Output = Result<Option<WebFingerResponse>, ProviderError>> + 'a;
+}
+
+/// A provider backed by a static parsed configuration.
+///
+/// This provider is useful for local servers, tests, examples, and deployments where configuration
+/// is loaded before request handling begins. It applies the same exact resource matching and
+/// relation filtering described by [`WebFingerProvider`].
+#[derive(Debug, Clone)]
+pub struct StaticConfigProvider {
+    config: Config,
+}
+
+impl StaticConfigProvider {
+    /// Parses a static TOML configuration.
+    pub fn from_toml(input: &str) -> Result<Self, ConfigError> {
+        Ok(Self {
+            config: Config::from_toml(input)?,
+        })
+    }
+
+    /// Creates a provider from an already parsed configuration.
+    pub fn new(config: Config) -> Self {
+        Self { config }
+    }
+
+    /// Resolves a request against this provider without an async boundary.
+    ///
+    /// Use this when the caller is already inside synchronous code and does not need the
+    /// [`WebFingerProvider`] abstraction.
+    pub fn resolve_config(&self, request: &WebFingerRequest) -> Option<WebFingerResponse> {
+        self.config.resolve(request)
+    }
+}
+
+impl WebFingerProvider for StaticConfigProvider {
+    /// Resolves a request against the parsed static configuration.
+    async fn resolve<'a>(
+        &'a self,
+        request: &'a WebFingerRequest,
+    ) -> Result<Option<WebFingerResponse>, ProviderError> {
+        Ok(self.config.resolve(request))
+    }
+}
+
+/// Errors raised while loading or resolving provider data.
+///
+/// Provider errors describe failures at the data boundary. Runtime adapters log detailed provider
+/// errors, then decide how much information is safe to expose in HTTP responses.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ProviderError {
+    /// A runtime binding was missing.
+    #[error("missing runtime binding `{binding}`")]
+    Binding {
+        /// Binding name.
+        binding: String,
+        /// Safe runtime error message.
+        message: String,
+    },
+
+    /// The configured key does not exist.
+    #[error("missing configuration key `{key}`")]
+    MissingConfig {
+        /// Configuration key.
+        key: String,
+    },
+
+    /// Reading the configured key failed.
+    #[error("failed to read configuration key `{key}`: {message}")]
+    ReadConfig {
+        /// Configuration key.
+        key: String,
+        /// Safe runtime error message.
+        message: String,
+    },
+
+    /// The configuration was invalid.
+    #[error(transparent)]
+    Config(#[from] ConfigError),
+}

--- a/webfinger-service/src/tests.rs
+++ b/webfinger-service/src/tests.rs
@@ -1,0 +1,182 @@
+use super::*;
+use webfinger_rs::WebFingerRequest;
+
+const CONFIG: &str = r#"
+[[resources]]
+resource = "acct:alice@example.com"
+aliases = ["https://social.example/@alice"]
+
+[resources.properties]
+"https://example.com/ns/display-name" = "Alice"
+"https://example.com/ns/old-name" = { null = true }
+
+[[resources.links]]
+rel = "self"
+type = "application/activity+json"
+href = "https://social.example/users/alice"
+
+[[resources.links]]
+rel = "http://webfinger.net/rel/profile-page"
+type = "text/html"
+href = "https://social.example/@alice"
+
+[[resources.links]]
+rel = "http://ostatus.org/schema/1.0/subscribe"
+template = "https://social.example/authorize_interaction?uri={uri}"
+"#;
+
+#[test]
+fn parses_valid_toml_config() {
+    let config = Config::from_toml(CONFIG).unwrap();
+
+    let request = request("acct:alice@example.com", []);
+    let response = config.resolve(&request).unwrap();
+
+    assert_eq!(response.subject.as_ref(), "acct:alice@example.com");
+    assert_eq!(response.links.len(), 3);
+    assert_eq!(
+        response
+            .properties
+            .unwrap()
+            .get("https://example.com/ns/old-name"),
+        Some(&None),
+    );
+    assert_eq!(
+        response.links[2].template.as_deref(),
+        Some("https://social.example/authorize_interaction?uri={uri}"),
+    );
+}
+
+#[test]
+fn rejects_malformed_toml_config() {
+    let error = Config::from_toml("[[resources]").unwrap_err();
+
+    assert!(matches!(error, ConfigError::Toml(_)));
+}
+
+#[test]
+fn rejects_duplicate_resource_entries() {
+    let error = Config::from_toml(
+        r#"
+[[resources]]
+resource = "acct:alice@example.com"
+
+[[resources]]
+resource = "acct:alice@example.com"
+"#,
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        ConfigError::DuplicateResource(resource)
+            if resource == "acct:alice@example.com"
+    ));
+}
+
+#[test]
+fn rejects_false_resource_property_null_marker() {
+    let error = Config::from_toml(
+        r#"
+[[resources]]
+resource = "acct:alice@example.com"
+
+[resources.properties]
+"https://example.com/ns/display-name" = { null = false }
+"#,
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        ConfigError::InvalidNullProperty(property)
+            if property == "https://example.com/ns/display-name"
+    ));
+}
+
+#[test]
+fn rejects_false_link_property_null_marker() {
+    let error = Config::from_toml(
+        r#"
+[[resources]]
+resource = "acct:alice@example.com"
+
+[[resources.links]]
+rel = "self"
+
+[resources.links.properties]
+"https://example.com/ns/display-name" = { null = false }
+"#,
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        ConfigError::InvalidNullProperty(property)
+            if property == "https://example.com/ns/display-name"
+    ));
+}
+
+#[test]
+fn parses_empty_default_config() {
+    let config = Config::from_toml(include_str!("../webfinger.toml")).unwrap();
+
+    let request = request("acct:alice@example.com", []);
+
+    assert!(config.resolve(&request).is_none());
+}
+
+#[test]
+fn resolves_exact_resource_matches() {
+    let config = Config::from_toml(EXAMPLE_CONFIG).unwrap();
+
+    let request = request("acct:alice@example.com", []);
+
+    assert!(config.resolve(&request).is_some());
+}
+
+#[test]
+fn returns_none_for_unknown_resources() {
+    let config = Config::from_toml(EXAMPLE_CONFIG).unwrap();
+
+    let request = request("acct:bob@example.com", []);
+
+    assert!(config.resolve(&request).is_none());
+}
+
+#[test]
+fn omits_relation_filter_when_no_rel_is_requested() {
+    let config = Config::from_toml(EXAMPLE_CONFIG).unwrap();
+
+    let request = request("acct:alice@example.com", []);
+    let response = config.resolve(&request).unwrap();
+
+    assert_eq!(response.links.len(), 3);
+}
+
+#[test]
+fn filters_repeated_relation_requests() {
+    let config = Config::from_toml(EXAMPLE_CONFIG).unwrap();
+
+    let request = request(
+        "acct:alice@example.com",
+        [
+            "self",
+            "http://webfinger.net/rel/profile-page",
+            "http://webfinger.net/rel/avatar",
+        ],
+    );
+    let response = config.resolve(&request).unwrap();
+
+    assert_eq!(response.links.len(), 2);
+}
+
+fn request<const N: usize>(resource: &str, rels: [&str; N]) -> WebFingerRequest {
+    let mut builder = WebFingerRequest::builder(resource)
+        .unwrap()
+        .host("example.com");
+    for rel in rels {
+        builder = builder.rel(rel);
+    }
+    builder.build()
+}

--- a/webfinger-service/webfinger.example.toml
+++ b/webfinger-service/webfinger.example.toml
@@ -1,0 +1,20 @@
+[[resources]]
+resource = "acct:alice@example.com"
+aliases = [
+  "https://social.example/@alice",
+  "https://social.example/users/alice",
+]
+
+[[resources.links]]
+rel = "self"
+type = "application/activity+json"
+href = "https://social.example/users/alice"
+
+[[resources.links]]
+rel = "http://webfinger.net/rel/profile-page"
+type = "text/html"
+href = "https://social.example/@alice"
+
+[[resources.links]]
+rel = "http://ostatus.org/schema/1.0/subscribe"
+template = "https://social.example/authorize_interaction?uri={uri}"

--- a/webfinger-service/webfinger.toml
+++ b/webfinger-service/webfinger.toml
@@ -1,0 +1,1 @@
+resources = []

--- a/webfinger-viewer-worker/README.md
+++ b/webfinger-viewer-worker/README.md
@@ -1,7 +1,5 @@
 # WebFinger Viewer Worker
 
-[![Deploy to Cloudflare][deploy-button]][deploy-url]
-
 `webfinger-viewer-worker` is a Rust Cloudflare Worker that serves a WebFinger viewer and debugging
 UI. It is separate from the server-side WebFinger responder Worker and does not read responder
 configuration.
@@ -44,11 +42,12 @@ environment, not the developer machine.
 The Worker can be mounted below a path such as `/webfinger`. It still queries the standard target
 path on the same host, such as `https://example.com/.well-known/webfinger`.
 
-The checked-in Wrangler config enables Cloudflare's `global_fetch_strictly_public` compatibility
-flag. Public deployments need this because the viewer performs server-side `fetch()` calls back to
-the same zone. Without the flag, Cloudflare can route that subrequest to the zone origin while
-ignoring same-zone Worker routes, which appears in the viewer as a target `522` even though the same
-`/.well-known/webfinger` URL works from a browser or local `curl`.
+The checked-in `wrangler.viewer.toml` config enables Cloudflare's
+`global_fetch_strictly_public` compatibility flag. Public deployments need this because the viewer
+performs server-side `fetch()` calls back to the same zone. Without the flag, Cloudflare can route
+that subrequest to the zone origin while ignoring same-zone Worker routes, which appears in the
+viewer as a target `522` even though the same `/.well-known/webfinger` URL works from a browser or
+local `curl`.
 
 1. Install the local JavaScript tooling:
 
@@ -59,33 +58,33 @@ npm install
 1. Run a dry-run deploy:
 
 ```console
-npm run deploy:dry-run
+npm run deploy:viewer:dry-run
 ```
 
 1. Deploy to the temporary Workers route:
 
 ```console
-npm run deploy
+npm run deploy:viewer
 ```
 
 1. Deploy-test on a site route without committing site-specific config:
 
 ```console
-npx wrangler deploy \
+npx wrangler deploy --config wrangler.viewer.toml \
   --route 'example.com/webfinger' \
   --route 'example.com/webfinger/*'
 ```
 
 The route commands require the hostname's zone to be in the Cloudflare account and DNS to be set up
-for that hostname. The checked-in `wrangler.toml` intentionally does not contain Josh-specific
+for that hostname. The checked-in `wrangler.viewer.toml` intentionally does not contain Josh-specific
 routes or envs because this crate is a reusable tool, not a single-site deploy.
 
-The deploy button is a convenience for Cloudflare's Git-backed flow. It is most useful after the
-current branch is pushed to GitHub; the person deploying still needs to choose the account and add
-any desired route such as `example.com/webfinger*` in Cloudflare.
+The root Deploy to Cloudflare button is reserved for the service Worker because Cloudflare deploy
+buttons do not fully support this workspace as a multi-Worker monorepo. Deploy the viewer with the
+explicit viewer scripts above.
 
 Cloudflare's Git deploy environment may provide Node and npm without Rust. The checked-in
-`wrangler.toml` build hook runs `scripts/build-webfinger-viewer-worker.sh`, which installs a
+`wrangler.viewer.toml` build hook runs `scripts/build-webfinger-viewer-worker.sh`, which installs a
 minimal Rust toolchain only when `cargo` is missing, adds the Wasm target, and then runs
 `worker-build`. Local developers with Rust already installed use their existing toolchain.
 The repository intentionally does not use a root `rust-toolchain.toml`: the library docs workflow
@@ -94,7 +93,7 @@ Rust by itself.
 
 ## Observability
 
-`wrangler.toml` enables Cloudflare Worker observability. The Worker installs a console-backed
+`wrangler.viewer.toml` enables Cloudflare Worker observability. The Worker installs a console-backed
 `tracing` subscriber in wasm builds, so request decisions and lookup results appear in Wrangler tail
 and Cloudflare dashboard logs. Useful log events include:
 
@@ -108,7 +107,7 @@ and Cloudflare dashboard logs. Useful log events include:
 Run Wrangler locally:
 
 ```console
-npm run dev
+npm run dev:viewer
 ```
 
 Then open the local Wrangler URL and query a resource such as:
@@ -187,10 +186,8 @@ cargo fmt --all --check
 cargo test -p webfinger-viewer-worker
 cargo check -p webfinger-viewer-worker --target wasm32-unknown-unknown
 markdownlint-cli2 --no-globs webfinger-viewer-worker/README.md
-npm run deploy:dry-run
+npm run deploy:viewer:dry-run
 ```
 
-`npm run deploy:dry-run` runs `worker-build --release` through the `wrangler.toml` build hook.
-
-[deploy-button]: https://deploy.workers.cloudflare.com/button
-[deploy-url]: https://deploy.workers.cloudflare.com/?url=https://github.com/joshka/webfinger-rs
+`npm run deploy:viewer:dry-run` runs `worker-build --release` through the
+`wrangler.viewer.toml` build hook.

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,10 +1,17 @@
-name = "webfinger-viewer-worker"
-main = "webfinger-viewer-worker/build/worker/shim.mjs"
+name = "webfinger-service-worker"
+main = "webfinger-service-worker/build/worker/shim.mjs"
 compatibility_date = "2026-07-02"
-compatibility_flags = ["global_fetch_strictly_public"]
+
+# Replace this with your zone before deploying, or manage routes in the Cloudflare dashboard.
+# routes = [
+#   { pattern = "example.com/.well-known/webfinger*", zone_name = "example.com" },
+# ]
+
+[[kv_namespaces]]
+binding = "WEBFINGER_CONFIG"
 
 [build]
-command = "scripts/build-webfinger-viewer-worker.sh"
+command = "scripts/build-webfinger-service-worker.sh"
 
 [observability]
 enabled = true

--- a/wrangler.viewer.toml
+++ b/wrangler.viewer.toml
@@ -1,0 +1,10 @@
+name = "webfinger-viewer-worker"
+main = "webfinger-viewer-worker/build/worker/shim.mjs"
+compatibility_date = "2026-07-02"
+compatibility_flags = ["global_fetch_strictly_public"]
+
+[build]
+command = "scripts/build-webfinger-viewer-worker.sh"
+
+[observability]
+enabled = true


### PR DESCRIPTION
## Summary

- add a runtime-neutral `webfinger-service` crate for TOML-backed WebFinger config and provider traits
- add `webfinger-service-axum` as the native Axum server with Clap/env config, default and example config files, tracing, and clear bind/config errors
- add `webfinger-service-worker` as the Cloudflare Worker adapter backed by Workers KV
- document the core/Axum/Worker split and Deploy-to-Cloudflare path

## Validation

- `cargo fmt --all --check`
- `cargo test --workspace`
- `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- `cargo check -p webfinger-service-worker --target wasm32-unknown-unknown`
- `markdownlint-cli2 --no-globs README.md webfinger-service/README.md webfinger-service-axum/README.md webfinger-service-worker/README.md`
- `npm run deploy:dry-run`
- native smoke: default config returned `404`
- native smoke: `--example-config` returned `200 application/jrd+json`
