### PR TITLE
Add CORS to WebFinger error responses

### DIFF
--- a/webfinger-rs/src/actix.rs
+++ b/webfinger-rs/src/actix.rs
@@ -43,7 +43,12 @@
 //!
 //! If extraction fails, Actix returns `400 Bad Request` for missing or duplicated `resource`,
 //! missing host values, invalid percent encoding, relative resource references, or invalid resource
-//! URIs.
+//! URIs. Those bad-request responses include the same `Access-Control-Allow-Origin: *` header as
+//! successful JRD responses so browser clients can inspect WebFinger endpoint errors.
+//!
+//! Path and method rejections happen before the extractor runs. Applications that need CORS on
+//! Actix router-owned `404 Not Found` or method-mismatch responses should add route or middleware
+//! handling at the application boundary where those responses are generated.
 //!
 //! See also [`WebFingerRequest`] for the extractor impl, [`WebFingerResponse`] for the responder
 //! impl, and the [Actix example] for a runnable server.
@@ -55,10 +60,12 @@
 use std::future::{Ready, ready};
 
 use actix_web::dev::Payload;
-use actix_web::error::ErrorBadRequest;
+use actix_web::http::StatusCode;
 use actix_web::http::header::{ACCESS_CONTROL_ALLOW_ORIGIN, CONTENT_TYPE, HeaderValue};
 use actix_web::web::Json;
-use actix_web::{Error as ActixError, FromRequest, HttpRequest, HttpResponse, Responder};
+use actix_web::{
+    Error as ActixError, FromRequest, HttpRequest, HttpResponse, Responder, ResponseError,
+};
 use tracing::trace;
 
 use crate::http::CORS_ALLOW_ORIGIN;
@@ -134,11 +141,9 @@ impl FromRequest for WebFingerRequest {
     ///
     /// - If the request has zero or more than one `resource` query parameter, extraction returns a
     ///   bad request.
-    /// - If the request has no URI authority and no `Host` header, extraction returns
-    ///   `ErrorBadRequest("missing host")`.
+    /// - If the request has no URI authority and no `Host` header, extraction returns a bad request.
     /// - If the query contains malformed percent encoding, extraction returns a bad request.
-    /// - If `resource` is present but cannot be parsed as a URI, extraction returns
-    ///   `ErrorBadRequest("invalid resource: ...")`.
+    /// - If `resource` is present but cannot be parsed as a URI, extraction returns a bad request.
     ///
     /// See also the [`crate::actix`] module docs and the [Actix example].
     ///
@@ -180,14 +185,14 @@ fn extract_request(req: &HttpRequest) -> Result<WebFingerRequest, ActixError> {
         .host()
         .or_else(|| req.headers().get("host").and_then(|h| h.to_str().ok()))
         .map(|h| h.to_string())
-        .ok_or(ErrorBadRequest("missing host"))?;
+        .ok_or_else(|| bad_request("missing host"))?;
     let query: RequestParams = req.query_string().parse()?;
     let rels = query
         .rel
         .into_iter()
         .map(Rel::try_new)
         .collect::<Result<Vec<_>, _>>()
-        .map_err(ErrorBadRequest)?;
+        .map_err(bad_request)?;
     Ok(WebFingerRequest {
         host,
         resource: query.resource,
@@ -197,7 +202,43 @@ fn extract_request(req: &HttpRequest) -> Result<WebFingerRequest, ActixError> {
 
 impl From<RequestParamsError> for ActixError {
     fn from(error: RequestParamsError) -> Self {
-        ErrorBadRequest(error)
+        bad_request(error)
+    }
+}
+
+fn bad_request(error: impl ToString) -> ActixError {
+    WebFingerBadRequest {
+        message: error.to_string(),
+    }
+    .into()
+}
+
+/// Bad-request response for malformed WebFinger endpoint requests.
+///
+/// Actix's generic bad-request helper renders the right status and body but does not know that
+/// WebFinger endpoint errors need to be readable from browsers. Keeping this tiny response error
+/// local to the extractor preserves the existing error messages while adding the endpoint CORS
+/// header only to responses this adapter owns.
+#[derive(Debug)]
+struct WebFingerBadRequest {
+    message: String,
+}
+
+impl std::fmt::Display for WebFingerBadRequest {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.message.fmt(formatter)
+    }
+}
+
+impl ResponseError for WebFingerBadRequest {
+    fn status_code(&self) -> StatusCode {
+        StatusCode::BAD_REQUEST
+    }
+
+    fn error_response(&self) -> HttpResponse {
+        HttpResponse::build(self.status_code())
+            .insert_header((ACCESS_CONTROL_ALLOW_ORIGIN, CORS_ALLOW_ORIGIN_HEADER))
+            .body(self.message.clone())
     }
 }
 
@@ -251,6 +292,59 @@ mod tests {
         let response = test::call_service(&app, request).await;
 
         assert_eq!(response.status(), StatusCode::OK, "{response:?}");
+        assert_eq!(
+            response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN),
+            Some(&CORS_ALLOW_ORIGIN_HEADER),
+        );
+        Ok(())
+    }
+
+    /// Includes the RFC 7033 CORS header on malformed WebFinger requests.
+    ///
+    /// Browser clients need to read WebFinger error responses as well as successful JRD responses.
+    /// Missing `resource` is an extractor error that this adapter owns.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-5>.
+    #[actix_web::test]
+    async fn malformed_request_sets_cors_header() -> Result {
+        let app = App::new().route(WELL_KNOWN_PATH, web::get().to(webfinger));
+        let app = test::init_service(app).await;
+        let request = test::TestRequest::get()
+            .uri(WELL_KNOWN_PATH)
+            .insert_header(("host", "example.org"))
+            .to_request();
+
+        let response = test::call_service(&app, request).await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{response:?}");
+        assert_eq!(
+            response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN),
+            Some(&CORS_ALLOW_ORIGIN_HEADER),
+        );
+        Ok(())
+    }
+
+    /// Includes the RFC 7033 CORS header when duplicate resource parameters are rejected.
+    ///
+    /// This covers the ambiguous-request branch separately from a missing parameter, because both
+    /// are malformed WebFinger endpoint requests that browser clients should be able to inspect.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-5>.
+    #[actix_web::test]
+    async fn duplicate_resource_sets_cors_header() -> Result {
+        let app = App::new().route(WELL_KNOWN_PATH, web::get().to(webfinger));
+        let app = test::init_service(app).await;
+        let carol = "acct%3Acarol%40example.org";
+        let alice = "acct%3Aalice%40example.org";
+        let uri = format!("{WELL_KNOWN_PATH}?resource={carol}&resource={alice}");
+        let request = test::TestRequest::get()
+            .uri(&uri)
+            .insert_header(("host", "example.org"))
+            .to_request();
+
+        let response = test::call_service(&app, request).await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{response:?}");
         assert_eq!(
             response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN),
             Some(&CORS_ALLOW_ORIGIN_HEADER),

--- a/webfinger-rs/src/axum.rs
+++ b/webfinger-rs/src/axum.rs
@@ -41,7 +41,13 @@
 //!
 //! If extraction fails, Axum receives [`Rejection`], which returns `400 Bad Request` with a plain
 //! text message for missing or duplicated `resource`, missing host values, invalid percent
-//! encoding, relative resource references, or invalid resource URIs.
+//! encoding, relative resource references, or invalid resource URIs. Those rejection responses
+//! include the same `Access-Control-Allow-Origin: *` header as successful JRD responses so browser
+//! clients can inspect WebFinger endpoint errors.
+//!
+//! Path and method rejections happen before the extractor runs. Applications that need CORS on
+//! Axum's router-owned `404 Not Found` or `405 Method Not Allowed` responses should add route or
+//! middleware handling at the application boundary where those responses are generated.
 //!
 //! See also [`WebFingerRequest`] for the extractor impl, [`WebFingerResponse`] for the responder
 //! impl, and the [Axum example] for a runnable server.
@@ -159,7 +165,8 @@ impl IntoResponse for Rejection {
     /// Converts the rejection into a `400 Bad Request` Axum response.
     ///
     /// The body is a plain text error message intended to make local debugging and simple server
-    /// implementations straightforward.
+    /// implementations straightforward. The response includes the WebFinger CORS header so browser
+    /// clients can read malformed-request errors from the endpoint.
     ///
     /// See also the [`crate::axum`] module docs.
     fn into_response(self) -> AxumResponse {
@@ -169,7 +176,11 @@ impl IntoResponse for Rejection {
             Rejection::InvalidResource(error) => format!("invalid resource: {error}"),
             Rejection::InvalidRel(error) => error.to_string(),
         };
-        (StatusCode::BAD_REQUEST, message).into_response()
+        let cors_header = (
+            header::ACCESS_CONTROL_ALLOW_ORIGIN,
+            CORS_ALLOW_ORIGIN_HEADER,
+        );
+        (StatusCode::BAD_REQUEST, [cors_header], message).into_response()
     }
 }
 
@@ -373,6 +384,52 @@ mod tests {
         let response = app().oneshot(request).await?;
 
         assert_eq!(response.status(), StatusCode::OK, "{response:?}");
+        assert_eq!(
+            response.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN),
+            Some(&CORS_ALLOW_ORIGIN_HEADER),
+        );
+        Ok(())
+    }
+
+    /// Includes the RFC 7033 CORS header on malformed WebFinger requests.
+    ///
+    /// Browser clients need to read WebFinger error responses as well as successful JRD responses.
+    /// Missing `resource` is a framework-independent extractor rejection that this adapter owns.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-5>.
+    #[tokio::test]
+    async fn malformed_request_sets_cors_header() -> Result {
+        let request = Request::builder()
+            .uri(WELL_KNOWN_PATH)
+            .header(HOST, "example.com")
+            .body(Body::empty())?;
+
+        let response = app().oneshot(request).await?;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{response:?}");
+        assert_eq!(
+            response.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN),
+            Some(&CORS_ALLOW_ORIGIN_HEADER),
+        );
+        Ok(())
+    }
+
+    /// Includes the RFC 7033 CORS header when duplicate resource parameters are rejected.
+    ///
+    /// This covers the ambiguous-request branch separately from a missing parameter, because both
+    /// are malformed WebFinger endpoint requests that browser clients should be able to inspect.
+    ///
+    /// See <https://www.rfc-editor.org/rfc/rfc7033.html#section-5>.
+    #[tokio::test]
+    async fn duplicate_resource_sets_cors_header() -> Result {
+        let carol = "acct%3Acarol%40example.org";
+        let alice = "acct%3Aalice%40example.org";
+        let uri = format!("https://example.com{WELL_KNOWN_PATH}?resource={carol}&resource={alice}");
+        let request = Request::builder().uri(uri).body(Body::empty())?;
+
+        let response = app().oneshot(request).await?;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{response:?}");
         assert_eq!(
             response.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN),
             Some(&CORS_ALLOW_ORIGIN_HEADER),

--- a/webfinger-service-worker/src/lib.rs
+++ b/webfinger-service-worker/src/lib.rs
@@ -12,12 +12,19 @@
 //! Public HTTP error bodies intentionally avoid detailed provider/configuration failures, except
 //! for the missing setup key message. Detailed failures are logged through `tracing` for Wrangler
 //! tail and Cloudflare Worker logs.
+//!
+//! WebFinger responses use `Access-Control-Allow-Origin: *` because the endpoint is designed for
+//! public browser-readable discovery. The Worker applies that header to responses generated for
+//! `/.well-known/webfinger`, including malformed queries, unknown resources, unsupported methods,
+//! and provider failures. It does not add the WebFinger CORS header to unrelated paths such as
+//! `/health`, so adding another route does not accidentally make that route publicly readable from
+//! browsers.
 
 mod kv;
 mod observability;
 
 use axum::extract::FromRequestParts;
-use axum::http::{Method, StatusCode, header};
+use axum::http::{HeaderValue, Method, StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use thiserror::Error;
 use tracing::{error, info, instrument};
@@ -26,6 +33,8 @@ use webfinger_service::{ProviderError, WebFingerProvider};
 use worker::{Context, Env, HttpRequest};
 
 pub use crate::kv::{KvConfigProvider, WEBFINGER_CONFIG_BINDING};
+
+const CORS_ALLOW_ORIGIN_HEADER: HeaderValue = HeaderValue::from_static("*");
 
 /// A WebFinger Worker backed by a caller-provided provider.
 ///
@@ -87,12 +96,17 @@ where
     let path = request.uri().path().to_string();
     if method != Method::GET {
         log_webfinger_request(&method, &path, "method_not_allowed");
-        return (
+        let response = (
             StatusCode::METHOD_NOT_ALLOWED,
             [(header::ALLOW, Method::GET.as_str())],
             "method not allowed",
         )
             .into_response();
+        return if path == WELL_KNOWN_PATH {
+            with_webfinger_cors(response)
+        } else {
+            response
+        };
     }
     if path == "/health" {
         log_webfinger_request(&method, &path, "health");
@@ -111,10 +125,19 @@ where
         }
         Err(rejection) => {
             log_webfinger_request(&method, &path, "bad_request");
-            return rejection.into_response();
+            return with_webfinger_cors(rejection.into_response());
         }
     };
     webfinger(provider, request).await.into_response()
+}
+
+/// Adds the public WebFinger CORS header to a response already known to belong to the endpoint.
+fn with_webfinger_cors(mut response: Response) -> Response {
+    response.headers_mut().insert(
+        header::ACCESS_CONTROL_ALLOW_ORIGIN,
+        CORS_ALLOW_ORIGIN_HEADER,
+    );
+    response
 }
 
 #[instrument(skip(provider, request), fields(resource = %request.resource))]
@@ -149,7 +172,7 @@ enum HttpError {
 
 impl IntoResponse for HttpError {
     fn into_response(self) -> Response {
-        match self {
+        let response = match self {
             HttpError::NotFound => (StatusCode::NOT_FOUND, "resource not found").into_response(),
             HttpError::Provider(error) => {
                 error!(?error, "webfinger provider failed");
@@ -163,7 +186,8 @@ impl IntoResponse for HttpError {
                 };
                 (StatusCode::INTERNAL_SERVER_ERROR, message).into_response()
             }
-        }
+        };
+        with_webfinger_cors(response)
     }
 }
 
@@ -196,10 +220,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn unknown_resource_sets_cors_header() {
+        let response = call("/.well-known/webfinger?resource=acct:bob@example.com").await;
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(
+            response.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN),
+            Some(&CORS_ALLOW_ORIGIN_HEADER),
+        );
+    }
+
+    #[tokio::test]
     async fn maps_unknown_path_to_not_found() {
         let response = call("/").await;
 
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn unknown_path_does_not_set_webfinger_cors_header() {
+        let response = call("/").await;
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(
+            response.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN),
+            None,
+        );
     }
 
     #[tokio::test]
@@ -219,10 +265,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn unsupported_webfinger_method_sets_cors_header() {
+        let provider = StaticConfigProvider::from_toml(EXAMPLE_CONFIG).unwrap();
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/.well-known/webfinger?resource=acct:alice@example.com")
+            .header("host", "example.com")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = Worker::new(provider).serve(request).await;
+
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+        assert_eq!(
+            response.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN),
+            Some(&CORS_ALLOW_ORIGIN_HEADER),
+        );
+    }
+
+    #[tokio::test]
+    async fn unsupported_non_webfinger_method_does_not_set_cors_header() {
+        let provider = StaticConfigProvider::from_toml(EXAMPLE_CONFIG).unwrap();
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/health")
+            .header("host", "example.com")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = Worker::new(provider).serve(request).await;
+
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+        assert_eq!(
+            response.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN),
+            None,
+        );
+    }
+
+    #[tokio::test]
     async fn maps_malformed_query_to_bad_request() {
         let response = call("/.well-known/webfinger").await;
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn malformed_query_sets_cors_header() {
+        let response = call("/.well-known/webfinger").await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            response.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN),
+            Some(&CORS_ALLOW_ORIGIN_HEADER),
+        );
     }
 
     #[tokio::test]
@@ -236,6 +331,17 @@ mod tests {
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let response: WebFingerResponse = serde_json::from_slice(&body).unwrap();
         assert_eq!(response.subject.as_ref(), "acct:alice@example.com");
+    }
+
+    #[tokio::test]
+    async fn successful_response_sets_cors_header() {
+        let response = call("/.well-known/webfinger?resource=acct:alice@example.com").await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN),
+            Some(&CORS_ALLOW_ORIGIN_HEADER),
+        );
     }
 
     #[tokio::test]
@@ -257,6 +363,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn missing_config_sets_cors_header() {
+        let request = Request::builder()
+            .uri("/.well-known/webfinger?resource=acct:alice@example.com")
+            .header("host", "example.com")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = Worker::new(MissingConfigProvider).serve(request).await;
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(
+            response.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN),
+            Some(&CORS_ALLOW_ORIGIN_HEADER),
+        );
+    }
+
+    #[tokio::test]
     async fn provider_errors_do_not_expose_config_details() {
         let request = Request::builder()
             .uri("/.well-known/webfinger?resource=acct:alice@example.com")
@@ -272,6 +395,23 @@ mod tests {
         let body = String::from_utf8(body.to_vec()).unwrap();
         assert!(body.contains("Check the Worker logs"));
         assert!(!body.contains("acct:alice@example.com"));
+    }
+
+    #[tokio::test]
+    async fn provider_errors_set_cors_header() {
+        let request = Request::builder()
+            .uri("/.well-known/webfinger?resource=acct:alice@example.com")
+            .header("host", "example.com")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = Worker::new(InvalidConfigProvider).serve(request).await;
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(
+            response.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN),
+            Some(&CORS_ALLOW_ORIGIN_HEADER),
+        );
     }
 
     async fn call(uri: &str) -> Response {


### PR DESCRIPTION
## Summary

- add `Access-Control-Allow-Origin: *` to Axum and Actix WebFinger bad-request responses
- add CORS to Cloudflare Worker WebFinger error responses while leaving non-WebFinger routes untouched
- document the CORS ownership boundaries and add regression tests for success, error, and no-CORS cases

## Validation

- `cargo test -p webfinger-rs --all-features axum::tests`
- `cargo test -p webfinger-rs --all-features actix::tests`
- `cargo test -p webfinger-service-worker`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-features --all-targets`
- `cargo test --workspace`
